### PR TITLE
chore: standardize naming on sandboxd

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# sandboxed configuration. Copy to .env (install.sh does this for you):
+# sandboxd configuration. Copy to .env (install.sh does this for you):
 #   cp .env.example .env
 # All values have sensible defaults; the stack runs with an empty .env.
 
@@ -18,22 +18,22 @@ PREVIEW_TLS=false
 HTTP_PORT=80
 
 # ── Images & network ─────────────────────────────────────────────────
-SANDBOXED_IMAGE=sandboxed-base:1.0.0
-SANDBOXED_NETWORK=sandboxed_net
+SANDBOXD_IMAGE=sandboxd-base:1.0.0
+SANDBOXD_NETWORK=sandboxd_net
 
 # ── Storage ──────────────────────────────────────────────────────────
 # Workspaces, SQLite state and the shared access log live here. MUST be
 # an absolute path; it is bind-mounted host:container symmetric (see
 # docker-compose.yml). NOTE: the OSS build stores each workspace as a
 # plain directory — there is NO hard per-workspace disk quota.
-SANDBOXED_DATA_DIR=/var/lib/sandboxed
-SANDBOXED_LOG_DIR=/var/lib/sandboxed/log
+SANDBOXD_DATA_DIR=/var/lib/sandboxed
+SANDBOXD_LOG_DIR=/var/lib/sandboxed/log
 
 # Where the control-plane API is published on the host. The default
 # avoids the common 9000 clash; the upstream backend / your scripts talk
 # to it here. Set to e.g. 0.0.0.0:9090 to expose on the LAN (then you
 # SHOULD enable auth below).
-SANDBOXED_API_BIND=127.0.0.1:9090
+SANDBOXD_API_BIND=127.0.0.1:9090
 
 # ── Auth ─────────────────────────────────────────────────────────────
 # Open by default for local use. For any non-local deployment set
@@ -46,7 +46,7 @@ SANDBOXD_API_TOKENS=
 # Write cgroup v2 memory.high after start (soft throttle). Needs host
 # cgroup access the control-plane container usually lacks, so it is OFF
 # by default; the hard --memory ceiling on each sandbox still applies.
-SANDBOXED_SET_MEMORY_HIGH=false
+SANDBOXD_SET_MEMORY_HIGH=false
 
 # Idle window before a sandbox is stopped (docker stop) to free RAM.
 # 2100s = 35 min. Workspace is preserved; next request wakes it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
-# AGENTS.md — operating sandboxed
+# AGENTS.md — operating sandboxd
 
 A complete, self-contained runbook for an AI agent (or a human) to install, run,
-use, and remove **sandboxed** with no outside knowledge. Commands are
+use, and remove **sandboxd** with no outside knowledge. Commands are
 copy-pasteable. Human-readable docs: [`README.md`](README.md),
 [`ARCHITECTURE.md`](ARCHITECTURE.md).
 
@@ -21,12 +21,12 @@ wake on the next request. Workspaces persist on disk.
 
 ## Install
 ```bash
-git clone https://github.com/tastyeffectco/sandboxes.git
+git clone https://github.com/tastyeffectco/sandboxd.git
 cd sandboxes
 ./install.sh
 ```
 `install.sh` is idempotent. It: checks Docker, copies `.env.example`→`.env`,
-builds the base image (`sandboxed-base:1.0.0`) and the control plane, creates the
+builds the base image (`sandboxd-base:1.0.0`) and the control plane, creates the
 data dir, and runs `docker compose up -d`. The base-image build takes a few
 minutes the first time, then caches.
 
@@ -34,7 +34,7 @@ Configuration lives in `.env` (all keys documented in `.env.example`). The two
 you may change before installing:
 - `HTTP_PORT` (default `80`) — set to e.g. `8088` if port 80 is taken; preview
   URLs then include it.
-- `SANDBOXED_API_BIND` (default `127.0.0.1:9090`) — where the API is published.
+- `SANDBOXD_API_BIND` (default `127.0.0.1:9090`) — where the API is published.
 
 Verify it's up:
 ```bash
@@ -43,7 +43,7 @@ curl -s http://127.0.0.1:9090/readyz    # -> ready
 ```
 
 ## Core API
-Base URL = `http://${SANDBOXED_API_BIND}` (default `http://127.0.0.1:9090`).
+Base URL = `http://${SANDBOXD_API_BIND}` (default `http://127.0.0.1:9090`).
 Auth is **off by default** (local). If you set `SANDBOXD_API_AUTH_DISABLED=false`
 + `SANDBOXD_API_TOKENS=name:secret`, add `-H "Authorization: Bearer secret"`.
 
@@ -114,7 +114,7 @@ docker exec -it -e ANTHROPIC_API_KEY=sk-ant-... s-$ID bash   # then: claude
 docker compose logs -f sandboxd   # control-plane logs
 docker compose ps                 # stack status
 docker compose restart sandboxd   # restart control plane
-docker ps --filter label=sandboxed.managed=true   # list running sandboxes
+docker ps --filter label=sandboxd.managed=true   # list running sandboxes
 ```
 
 ## Uninstall
@@ -136,4 +136,4 @@ docker ps --filter label=sandboxed.managed=true   # list running sandboxes
 - **Preview shows "Spinning up your app…"** — the sandbox was stopped and is
   waking; it also shows if nothing is listening on the requested port yet.
 - **Seeding/permission errors on create** — the daemon likely uses
-  `userns-remap`; keep the default `SANDBOXED_USERNS=host`.
+  `userns-remap`; keep the default `SANDBOXD_USERNS=host`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-sandboxed is a small Go control plane (`sandboxd`) that drives the Docker
+sandboxd is a small Go control plane (`sandboxd`) that drives the Docker
 daemon, fronted by Traefik. Everything runs as containers on one host.
 
 ```
@@ -24,7 +24,7 @@ data directory mounted. It:
 - **Owns sandbox lifecycle** — create / list / get / exec / stop / destroy. It
   shells out to the `docker` CLI (`internal/docker`); no SDK.
 - **Provisions workspaces** (`internal/loopback`) — one directory per sandbox
-  under `SANDBOXED_DATA_DIR/workspaces/<id>`, seeded once from the image's
+  under `SANDBOXD_DATA_DIR/workspaces/<id>`, seeded once from the image's
   `/opt/sandbox-skel`, then bind-mounted into the container at `/home/sandbox`.
 - **Emits Traefik labels** (`internal/traefik`) so each sandbox self-registers
   its preview route(s) when it starts.
@@ -46,7 +46,7 @@ supervises the user's dev server and runs coding tasks submitted through the
 API. It's compiled in the base image's build stage, so the host needs no Go.
 
 ### Traefik (edge)
-Docker label provider, scoped by a `sandboxed.managed=true` constraint so it
+Docker label provider, scoped by a `sandboxd.managed=true` constraint so it
 only routes containers this stack owns. Running sandboxes win on a
 priority-100 router; the priority-1 file-provider catch-all (`traefik/dynamic/
 wake.yml`) forwards anything else to sandboxd's wake path. Plain HTTP by
@@ -69,15 +69,15 @@ Each sandbox runs under hardened `runc`: `--cap-drop=ALL`,
 `/tmp`, a hard `--memory` ceiling, `--pids-limit`, and file-descriptor ulimits.
 The threat model is **authenticated, accountable users running their own code**
 — not anonymous hostile multi-tenancy. Kernel-CVE container escape is mitigated
-by patching, not by a VM boundary; if you need stronger isolation, run sandboxed
+by patching, not by a VM boundary; if you need stronger isolation, run sandboxd
 on a dedicated VM per trust domain.
 
 ## Storage & persistence
 
 | Class | Where | Survives stop? | Survives reboot? |
 |---|---|---|---|
-| Workspace | `SANDBOXED_DATA_DIR/workspaces/<id>/` (bind mount) | yes | yes |
-| Control-plane state | `SANDBOXED_DATA_DIR/state/sandboxd.db` (SQLite) | yes | yes |
+| Workspace | `SANDBOXD_DATA_DIR/workspaces/<id>/` (bind mount) | yes | yes |
+| Control-plane state | `SANDBOXD_DATA_DIR/state/sandboxd.db` (SQLite) | yes | yes |
 | Container writable layer | none (`--read-only`) | no | no |
 | `/tmp`, `/var/tmp` | tmpfs | no | no |
 
@@ -86,14 +86,14 @@ workspace by copying its directory; back up state by copying the SQLite file.
 
 ## Design choices & current limitations (v1)
 
-sandboxed v1 optimizes for "runs anywhere with just Docker, one command." A few
+sandboxd v1 optimizes for "runs anywhere with just Docker, one command." A few
 mechanisms are deliberately simple so there's nothing host-specific to install
 or configure. Each is a conscious trade-off you can tighten later:
 
 | Area | v1 choice | Trade-off / how to harden |
 |---|---|---|
 | Workspace storage | plain **directory** per sandbox | no hard per-workspace disk quota (host fs is shared); add quotas at the fs/volume layer if needed |
-| Memory | hard `--memory` ceiling per sandbox | the softer cgroup `memory.high` throttle is opt-in (`SANDBOXED_SET_MEMORY_HIGH`, needs host cgroup access) |
+| Memory | hard `--memory` ceiling per sandbox | the softer cgroup `memory.high` throttle is opt-in (`SANDBOXD_SET_MEMORY_HIGH`, needs host cgroup access) |
 | Egress | default-allow, no logging | add host firewall rules / a proxy if you need egress control |
 | Package installs | public npm/PyPI registries | run your own caching proxy and point the image at it for speed/airgap |
 | TLS / domain | HTTP on `*.localhost` out of the box | switch to a real wildcard domain + cert resolver (see README → Production / TLS) |
@@ -101,5 +101,5 @@ or configure. Each is a conscious trade-off you can tighten later:
 
 `--userns=host` is set on the infra containers (and, by default, on sandboxes)
 so workspace ownership is deterministic whether or not the host daemon uses
-userns-remap. Set `SANDBOXED_USERNS=` empty to opt sandboxes back into the
+userns-remap. Set `SANDBOXD_USERNS=` empty to opt sandboxes back into the
 daemon default.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to sandboxed
+# Contributing to sandboxd
 
-Thanks for your interest! sandboxed aims to stay **small, reliable, and easy to
+Thanks for your interest! sandboxd aims to stay **small, reliable, and easy to
 self-host**. We favour a tight, well-understood core over feature breadth.
 
 ## Project layout
 
 ```
-sandboxed/
+sandboxd/
 ├── docker-compose.yml     # the full stack: traefik + sandboxd
 ├── install.sh             # one-click installer
 ├── .env.example           # all configuration, with defaults
@@ -31,7 +31,7 @@ go vet ./...
 ```
 
 To exercise the whole stack, run `./install.sh` (or `docker compose up -d
---build`) and hit the API on `SANDBOXED_API_BIND`. The base image build is the
+--build`) and hit the API on `SANDBOXD_API_BIND`. The base image build is the
 slow part; it's cached after the first run.
 
 ## Guidelines

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 sandboxed contributors
+Copyright (c) 2026 sandboxd contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">sandboxed</h1>
+<h1 align="center">sandboxd</h1>
 
 
 <p align="center">
@@ -16,14 +16,14 @@
 
 ---
 
-<img width="1100" height="816" alt="sandboxed-demo" src="https://github.com/user-attachments/assets/f794ff9b-8ffe-47e8-bd30-22541f870f09" />
+<img width="1100" height="816" alt="sandboxd-demo" src="https://github.com/user-attachments/assets/f794ff9b-8ffe-47e8-bd30-22541f870f09" />
 
 
-## What is sandboxed? (start here)
+## What is sandboxd? (start here)
 
 Think of the apps where you type *"build me a todo app"* and seconds later a
 working website appears at its own link — like Lovable, Bolt, v0, or Replit.
-**sandboxed is the open-source backend that makes that possible**, running on
+**sandboxd is the open-source backend that makes that possible**, running on
 your own server.
 
 Here's what it does, in plain terms. You send it one HTTP request, and it:
@@ -73,7 +73,7 @@ for a team.
 script, `docker run`, or [lxd](https://canonical.com/lxd) is simpler. (More on
 that [below](#why-not-just-a-shell-script).)
 
-## Why sandboxed?
+## Why sandboxd?
 
 If you're building an **AI app-builder, an agent platform, a coding playground,
 or a per-user preview product**, the hard part isn't the prompt — it's the
@@ -86,7 +86,7 @@ infrastructure underneath it:
   progress, capture the result.
 - **Persistence, wake-on-demand, reconciliation after a crash or reboot.**
 
-That's months of platform work. sandboxed is that platform, distilled to one
+That's months of platform work. sandboxd is that platform, distilled to one
 command:
 
 - ⚡ **One-command install.** `./install.sh` and you have a working API + previews.
@@ -105,7 +105,7 @@ command:
 
 Fair question — and honestly: **if you need one or two long-lived containers for
 yourself, a shell script (or `docker run`, or [lxd](https://canonical.com/lxd))
-is simpler. Use that.** We mean it. sandboxed is overkill for one-off projects.
+is simpler. Use that.** We mean it. sandboxd is overkill for one-off projects.
 
 It earns its keep the moment you're running **many** sandboxes for **other
 people** — a team, or a product — because that's when the tidy little `docker
@@ -128,7 +128,7 @@ run` script quietly grows into all of this:
 - **Agents with a lifecycle.** Submit a prompt, stream progress (SSE), capture a
   durable result — not just `opencode` fired inline.
 
-Rebuild those as your script grows and you've rebuilt sandboxed. So: skip it for
+Rebuild those as your script grows and you've rebuilt sandboxd. So: skip it for
 one-offs; reach for it when "just a script" has started keeping you up at night.
 
 > **Prefer Kubernetes?** The control plane talks to the container runtime through
@@ -144,7 +144,7 @@ Requirements: **Docker Engine + the Compose plugin**, on Linux. That's it.
 ### 1. Install
 
 ```bash
-git clone https://github.com/tastyeffectco/sandboxes.git
+git clone https://github.com/tastyeffectco/sandboxd.git
 cd sandboxes
 ./install.sh
 ```
@@ -206,7 +206,7 @@ real domain you get `https://s-<id>-3000.preview.yourdomain.com`
 
 ## API
 
-Base URL = `http://127.0.0.1:9090` (set by `SANDBOXED_API_BIND`). Auth is **off
+Base URL = `http://127.0.0.1:9090` (set by `SANDBOXD_API_BIND`). Auth is **off
 by default** for local use; with `SANDBOXD_API_AUTH_DISABLED=false` +
 `SANDBOXD_API_TOKENS`, send `-H "Authorization: Bearer <secret>"`.
 
@@ -253,8 +253,8 @@ The defaults run a complete local stack. The knobs you'll touch most:
 |---|---|---|
 | `PREVIEW_DOMAIN` | `localhost` | domain preview URLs hang off |
 | `HTTP_PORT` | `80` | host port Traefik listens on |
-| `SANDBOXED_DATA_DIR` | `/var/lib/sandboxed` | where workspaces + state live |
-| `SANDBOXED_API_BIND` | `127.0.0.1:9090` | where the control-plane API is published |
+| `SANDBOXD_DATA_DIR` | `/var/lib/sandboxed` | where workspaces + state live |
+| `SANDBOXD_API_BIND` | `127.0.0.1:9090` | where the control-plane API is published |
 | `SANDBOXD_API_AUTH_DISABLED` | `true` | open API for local use; set `false` + tokens for prod |
 
 ## Production / TLS
@@ -279,22 +279,22 @@ For a public deployment on a real wildcard domain:
 ./uninstall.sh --all      # full removal: images + data
 ```
 
-Safe by default — it removes only what sandboxed created (containers labelled
-`sandboxed.managed=true`, the compose stack, the network) and **keeps your
+Safe by default — it removes only what sandboxd created (containers labelled
+`sandboxd.managed=true`, the compose stack, the network) and **keeps your
 workspaces** unless you pass `--data`/`--all`.
 
 ## Is this a good foundation for a startup?
 
 Yes — that's exactly the point. If you want to ship an **AI app-builder or agent
 SaaS** without first spending months building multi-tenant isolation, preview
-routing, idle/wake cost control, and agent orchestration, sandboxed gives you
+routing, idle/wake cost control, and agent orchestration, sandboxd gives you
 that core on day one, on a single inexpensive server, with margins you control.
 It's a **strong, honest starting point** — beta-quality, MIT-licensed, and built
 to be read and extended. Launch lean on it; harden as you grow (next section).
 
 ## Before you scale hard: what's simple on purpose, and what to harden
 
-sandboxed v1 is tuned for "**works anywhere with just Docker, in one command**."
+sandboxd v1 is tuned for "**works anywhere with just Docker, in one command**."
 To keep it that simple, a few things were left basic **on purpose**. None of
 them affect the core loop (create → build → preview → sleep → wake → persist) —
 they're the knobs to tighten once you have real users and real money on the line.

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 #
-# sandboxd — the sandboxed control plane.
+# sandboxd — the sandboxd control plane.
 #
 # Two stages: a CGO build (sandboxd uses mattn/go-sqlite3, which needs
 # cgo + a C toolchain), then a slim runtime that carries the docker CLI

--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -1,6 +1,6 @@
 # sandboxd — control plane
 
-The Go control plane for [sandboxed](../README.md). A single binary that drives
+The Go control plane for [sandboxd](../README.md). A single binary that drives
 the Docker daemon (via the `docker` CLI), stores state in SQLite, runs the idle
 and pressure reapers, and serves the HTTP API and the wake path.
 
@@ -44,11 +44,11 @@ from `../.env`. The ones the OSS build adds or changes:
 | `PREVIEW_DOMAIN` | `localhost` | domain preview URLs hang off |
 | `PREVIEW_ENTRYPOINT` | `web` | Traefik entrypoint on preview routers |
 | `PREVIEW_TLS` | `false` | emit `tls=true` on preview routers |
-| `SANDBOXED_NETWORK` | `sandboxed_net` | docker network sandboxes join |
-| `SANDBOXED_USERNS` | `host` | `--userns` for sandboxes + the seed container |
-| `SANDBOXED_DATA_DIR` | `/var/lib/sandboxed` | workspaces + SQLite + logs |
-| `SANDBOXED_SET_MEMORY_HIGH` | `false` | write cgroup `memory.high` (needs host cgroup access) |
-| `SANDBOXD_IMAGE` | `sandboxed-base:1.0.0` | per-sandbox base image |
+| `SANDBOXD_NETWORK` | `sandboxd_net` | docker network sandboxes join |
+| `SANDBOXD_USERNS` | `host` | `--userns` for sandboxes + the seed container |
+| `SANDBOXD_DATA_DIR` | `/var/lib/sandboxed` | workspaces + SQLite + logs |
+| `SANDBOXD_SET_MEMORY_HIGH` | `false` | write cgroup `memory.high` (needs host cgroup access) |
+| `SANDBOXD_IMAGE` | `sandboxd-base:1.0.0` | per-sandbox base image |
 | `SANDBOXD_API_AUTH_DISABLED` | `true` | open API for local use |
 | `SANDBOXD_API_TOKENS` | — | `name:secret` pairs for service-token auth |
 | `SANDBOXD_IDLE_THRESHOLD_SECONDS` | `2100` | idle window before `docker stop` |

--- a/control-plane/cmd/runtimed/main.go
+++ b/control-plane/cmd/runtimed/main.go
@@ -18,7 +18,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/runtime"
 )
 
 const version = "0.1.0"

--- a/control-plane/cmd/runtimed/opencode.go
+++ b/control-plane/cmd/runtimed/opencode.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/runtime"
 )
 
 // agentSpec is the input to an agent adapter run.

--- a/control-plane/cmd/runtimed/opencode_test.go
+++ b/control-plane/cmd/runtimed/opencode_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sandboxed/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/runtime"
 )
 
 // captured records the (type, data) of every event the parser emits,

--- a/control-plane/cmd/runtimed/task.go
+++ b/control-plane/cmd/runtimed/task.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/runtime"
 )
 
 var errTaskInProgress = errors.New("a task is already in progress")

--- a/control-plane/cmd/sandboxd/backfill_legacy.go
+++ b/control-plane/cmd/sandboxd/backfill_legacy.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/logging"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/logging"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // runBackfillLegacy implements the one-shot subcommand
@@ -50,7 +50,7 @@ func runBackfillLegacy(args []string) int {
 			}
 		}
 	}
-	dataDir := envDefault("SANDBOXED_DATA_DIR", defaultDataDir)
+	dataDir := envDefault("SANDBOXD_DATA_DIR", defaultDataDir)
 	workspacesRoot := filepath.Join(dataDir, "workspaces")
 	dsn := fmt.Sprintf("file:%s?_journal=WAL&_busy_timeout=5000&_fk=1",
 		envDefault("SANDBOXD_DB", filepath.Join(dataDir, "state", "sandboxd.db")))

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -1,4 +1,4 @@
-// sandboxd — control plane for the sandboxed.
+// sandboxd — control plane for the sandboxd.
 //
 // CLAUDE.md control-plane scope: "Single Go binary, ~500–800 LOC
 // target. Binds to 127.0.0.1 only. No auth in v1 (introduced in
@@ -30,37 +30,37 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/activity"
-	"github.com/sandboxed/control-plane/internal/api"
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/idlock"
-	"github.com/sandboxed/control-plane/internal/logging"
-	"github.com/sandboxed/control-plane/internal/loopback"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	nginxwatch "github.com/sandboxed/control-plane/internal/nginx"
-	"github.com/sandboxed/control-plane/internal/reaper"
-	"github.com/sandboxed/control-plane/internal/reconcile"
-	"github.com/sandboxed/control-plane/internal/snapshot"
-	"github.com/sandboxed/control-plane/internal/store"
-	"github.com/sandboxed/control-plane/internal/wake"
+	"github.com/sandboxd/control-plane/internal/activity"
+	"github.com/sandboxd/control-plane/internal/api"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/idlock"
+	"github.com/sandboxd/control-plane/internal/logging"
+	"github.com/sandboxd/control-plane/internal/loopback"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	nginxwatch "github.com/sandboxd/control-plane/internal/nginx"
+	"github.com/sandboxd/control-plane/internal/reaper"
+	"github.com/sandboxd/control-plane/internal/reconcile"
+	"github.com/sandboxd/control-plane/internal/snapshot"
+	"github.com/sandboxd/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/wake"
 )
 
 const (
 	// OSS default: sandboxd runs in its own container and Traefik
 	// reaches it over the compose network by service name, so it binds
 	// all interfaces (it is NOT published to the host — only reachable
-	// on the internal sandboxed_net). Override with SANDBOXD_ADDR.
+	// on the internal sandboxd_net). Override with SANDBOXD_ADDR.
 	defaultListenAddr = "0.0.0.0:9000"
-	defaultImage      = "sandboxed-base:1.0.0"
+	defaultImage      = "sandboxd-base:1.0.0"
 	migrationsDir     = "/usr/local/share/sandboxd/migrations"
 
 	// Default data root for the portable build. The compose file
 	// bind-mounts this path host:container symmetric, so it is a valid
 	// host path for the sibling `docker run -v`. Override with
-	// SANDBOXED_DATA_DIR / SANDBOXED_LOG_DIR (paths derived in main()).
+	// SANDBOXD_DATA_DIR / SANDBOXD_LOG_DIR (paths derived in main()).
 	defaultDataDir = "/var/lib/sandboxed"
 	defaultLogDir  = "/var/log/sandboxed"
 
@@ -112,8 +112,8 @@ func main() {
 	// dataDir; the compose file bind-mounts dataDir host:container
 	// symmetric so the path sandboxd writes is also a valid host path
 	// for the sibling `docker run -v <workspace>:/home/sandbox`.
-	dataDir := envDefault("SANDBOXED_DATA_DIR", defaultDataDir)
-	logDir := envDefault("SANDBOXED_LOG_DIR", defaultLogDir)
+	dataDir := envDefault("SANDBOXD_DATA_DIR", defaultDataDir)
+	logDir := envDefault("SANDBOXD_LOG_DIR", defaultLogDir)
 	stateDir := filepath.Join(dataDir, "state")
 	dbPath := filepath.Join(stateDir, "sandboxd.db")
 	workspacesRoot := filepath.Join(dataDir, "workspaces")
@@ -124,11 +124,11 @@ func main() {
 	tailerOffsetFs := filepath.Join(stateDir, "traefik-tail.offset")
 
 	// OSS docker-native toggles (default to the portable behaviour).
-	network := os.Getenv("SANDBOXED_NETWORK")              // shared docker network for Traefik routing
-	userns := envDefault("SANDBOXED_USERNS", "host")       // sandbox + seed --userns; "host" is deterministic on any daemon
+	network := os.Getenv("SANDBOXD_NETWORK")              // shared docker network for Traefik routing
+	userns := envDefault("SANDBOXD_USERNS", "host")       // sandbox + seed --userns; "host" is deterministic on any daemon
 	previewEntrypoint := envDefault("PREVIEW_ENTRYPOINT", "web")
 	previewTLS := boolFromEnv("PREVIEW_TLS", false)
-	setMemoryHigh := boolFromEnv("SANDBOXED_SET_MEMORY_HIGH", false)
+	setMemoryHigh := boolFromEnv("SANDBOXD_SET_MEMORY_HIGH", false)
 
 	migrations := envDefault("SANDBOXD_MIGRATIONS", migrationsDir)
 	if _, err := os.Stat(migrations); err != nil {
@@ -480,8 +480,8 @@ func main() {
 	// for npm/pypi/crates/bun and hot-reloaded it on config change. The
 	// OSS image points package managers at the public registries
 	// directly, so there is no proxy container to watch. Re-enable by
-	// running your own proxy and setting SANDBOXED_NGINX_WATCH_PATHS +
-	// SANDBOXED_NGINX_CONTAINER (the watcher code is retained).
+	// running your own proxy and setting SANDBOXD_NGINX_WATCH_PATHS +
+	// SANDBOXD_NGINX_CONTAINER (the watcher code is retained).
 	_ = nginxwatch.ExecResult{} // keep the import referenced
 
 	// --- Auto-snapshotter: DISABLED in the OSS build ------------------

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -1,4 +1,4 @@
-module github.com/sandboxed/control-plane
+module github.com/sandboxd/control-plane
 
 go 1.22
 

--- a/control-plane/internal/activity/inflight_exec.go
+++ b/control-plane/internal/activity/inflight_exec.go
@@ -17,7 +17,7 @@ package activity
 import (
 	"sync"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 // InflightExec is a tiny thread-safe counter map: how many exec calls

--- a/control-plane/internal/activity/poller.go
+++ b/control-plane/internal/activity/poller.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Poller scrapes Traefik's Prometheus metrics endpoint and bumps

--- a/control-plane/internal/activity/tailer.go
+++ b/control-plane/internal/activity/tailer.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Tailer reads Traefik's JSON access log and, for each line whose

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -10,17 +10,17 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/sandboxed/control-plane/internal/activity"
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/idlock"
-	"github.com/sandboxed/control-plane/internal/loopback"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/snapshot"
-	"github.com/sandboxed/control-plane/internal/store"
-	"github.com/sandboxed/control-plane/internal/wake"
+	"github.com/sandboxd/control-plane/internal/activity"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/idlock"
+	"github.com/sandboxd/control-plane/internal/loopback"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/snapshot"
+	"github.com/sandboxd/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/wake"
 )
 
 // Server bundles the collaborators the handlers need.
@@ -34,7 +34,7 @@ type Server struct {
 
 	// OSS docker-native knobs (see cmd/sandboxd/main.go for env wiring):
 	//   Network           — shared docker network sandboxes join so Traefik
-	//                        can route to them (e.g. sandboxed_net).
+	//                        can route to them (e.g. sandboxd_net).
 	//   PreviewEntrypoint — Traefik entrypoint on preview routers ("web"
 	//                        plain HTTP by default, "websecure" for TLS).
 	//   PreviewTLS        — emit tls=true on preview routers (needs a cert in

--- a/control-plane/internal/api/claim.go
+++ b/control-plane/internal/api/claim.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // claimReq is the body of POST /sandbox/{id}/claim.

--- a/control-plane/internal/api/external_purge.go
+++ b/control-plane/internal/api/external_purge.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 // purgeOne is the irreversible per-sandbox teardown shared by all

--- a/control-plane/internal/api/forward_auth.go
+++ b/control-plane/internal/api/forward_auth.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // handleForwardAuth is called by Traefik's forwardAuth middleware on

--- a/control-plane/internal/api/gitpush.go
+++ b/control-plane/internal/api/gitpush.go
@@ -23,7 +23,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 const gitPushTimeout = 90 * time.Second
@@ -111,7 +111,7 @@ func (s *Server) pushOnTaskFinish(sandboxID, taskID string) {
 	// 2. commit only if there are staged changes.
 	if _, err := git("diff", "--cached", "--quiet"); err != nil {
 		if out, cerr := git(
-			"-c", "user.email=sandboxd@sandboxed.local",
+			"-c", "user.email=sandboxd@sandboxd.local",
 			"-c", "user.name=sandboxd",
 			"commit", "-m", "task "+taskID); cerr != nil {
 			log.Warn("git push: commit failed", "out", out)

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -15,17 +15,17 @@ import (
 
 	"github.com/oklog/ulid/v2"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/cgroup"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/logging"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/runtime"
-	"github.com/sandboxed/control-plane/internal/snapshot"
-	"github.com/sandboxed/control-plane/internal/store"
-	"github.com/sandboxed/control-plane/internal/traefik"
-	"github.com/sandboxed/control-plane/internal/wake"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/cgroup"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/logging"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/snapshot"
+	"github.com/sandboxd/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/traefik"
+	"github.com/sandboxd/control-plane/internal/wake"
 )
 
 // --- request / response payloads ------------------------------------

--- a/control-plane/internal/api/preview_auth.go
+++ b/control-plane/internal/api/preview_auth.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
 )
 
 // handlePreviewAuth is the landing endpoint for a freshly minted

--- a/control-plane/internal/api/preview_common.go
+++ b/control-plane/internal/api/preview_common.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sandboxed/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/auth"
 )
 
 // authCfg returns the current auth config snapshot, or an empty config

--- a/control-plane/internal/api/taskwatch.go
+++ b/control-plane/internal/api/taskwatch.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/runtime"
 )
 
 const (

--- a/control-plane/internal/api/v1.go
+++ b/control-plane/internal/api/v1.go
@@ -16,9 +16,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/runtime"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // defaultTemplate is the one fixed snapshot variant in v1.

--- a/control-plane/internal/api/v1_files_write.go
+++ b/control-plane/internal/api/v1_files_write.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sandboxed/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/audit"
 )
 
 // PUT /v1/sandboxes/{id}/files?path=<rel> — atomic generic file write.

--- a/control-plane/internal/api/v1_snapshots.go
+++ b/control-plane/internal/api/v1_snapshots.go
@@ -17,9 +17,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // v1Snapshot is the public snapshot object.

--- a/control-plane/internal/api/v1_tasks.go
+++ b/control-plane/internal/api/v1_tasks.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/runtime"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // runtimeClientFor builds a runtime.Client for a sandbox's runtimed.

--- a/control-plane/internal/docker/docker.go
+++ b/control-plane/internal/docker/docker.go
@@ -37,7 +37,7 @@ func NewClient() *Client { return &Client{Bin: "docker"} }
 type RunSpec struct {
 	Name       string   // --name
 	Hostname   string   // --hostname
-	Network    string   // --network (OSS: shared sandboxed_net so Traefik can route)
+	Network    string   // --network (OSS: shared sandboxd_net so Traefik can route)
 	Userns     string   // --userns (OSS: "host" for deterministic workspace ownership)
 	ReadOnly   bool     // --read-only
 	CapDrop    []string // --cap-drop=ALL (passed once per entry)
@@ -164,7 +164,7 @@ func (cj *ContainerJSON) BridgeIP() string {
 	}
 	// Prefer the legacy default bridge if present, then fall back to the
 	// first network that has an IP. In the OSS build sandboxes join a
-	// user-defined network (sandboxed_net), so the "bridge" key is absent
+	// user-defined network (sandboxd_net), so the "bridge" key is absent
 	// and we must scan whatever network the container actually got.
 	if n, ok := cj.NetworkSettings.Networks["bridge"]; ok && n != nil && n.IPAddress != "" {
 		return n.IPAddress

--- a/control-plane/internal/egress/collector.go
+++ b/control-plane/internal/egress/collector.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 // Collector tails journalctl for kernel messages with prefix

--- a/control-plane/internal/egress/refresh_watch.go
+++ b/control-plane/internal/egress/refresh_watch.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 // RefreshWatcher observes the two systemd oneshot units that refresh

--- a/control-plane/internal/loopback/loopback.go
+++ b/control-plane/internal/loopback/loopback.go
@@ -7,7 +7,7 @@
 // userns-remap subuid math) which is hostile to a portable "runs fully
 // on Docker, one-click install" distribution.
 //
-// The OSS "sandboxed" build replaces the loopback with a plain
+// The OSS "sandboxd" build replaces the loopback with a plain
 // bind-mounted directory per sandbox under a single data root. The
 // trade-off is explicit and documented in the README: NO hard
 // per-workspace disk quota (the host filesystem is shared). Everything
@@ -47,7 +47,7 @@ type Manager struct {
 func New() *Manager {
 	return &Manager{
 		Root:      "/var/lib/sandboxed/workspaces",
-		SeedImage: "sandboxed-base:1.0.0",
+		SeedImage: "sandboxd-base:1.0.0",
 		DockerBin: "docker",
 		Userns:    "host",
 	}

--- a/control-plane/internal/metrics/metrics.go
+++ b/control-plane/internal/metrics/metrics.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Registry is the package-level Prometheus registry.

--- a/control-plane/internal/reaper/idle.go
+++ b/control-plane/internal/reaper/idle.go
@@ -24,11 +24,11 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/activity"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/activity"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // IdleConfig captures the env-tunable knobs from roadmap §12. Defaults

--- a/control-plane/internal/reaper/pressure.go
+++ b/control-plane/internal/reaper/pressure.go
@@ -6,11 +6,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/activity"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/activity"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // PressureConfig captures the env-tunable knobs from roadmap §12.

--- a/control-plane/internal/reconcile/reconcile.go
+++ b/control-plane/internal/reconcile/reconcile.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/cgroup"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/loopback"
-	"github.com/sandboxed/control-plane/internal/snapshot"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/cgroup"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/loopback"
+	"github.com/sandboxd/control-plane/internal/snapshot"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Result is what Once returns to the caller (main.go logs + metrics).

--- a/control-plane/internal/snapshot/restore.go
+++ b/control-plane/internal/snapshot/restore.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // RestoreResult is returned to the API caller on success.

--- a/control-plane/internal/snapshot/snapshot.go
+++ b/control-plane/internal/snapshot/snapshot.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/idlock"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/idlock"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // tsLayout is the timestamp format embedded in snapshot filenames.

--- a/control-plane/internal/snapshot/snapshotter.go
+++ b/control-plane/internal/snapshot/snapshotter.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/metrics"
 )
 
 // Snapshotter is the hourly auto-snapshot goroutine. roadmap §9:

--- a/control-plane/internal/snapshot/take.go
+++ b/control-plane/internal/snapshot/take.go
@@ -9,8 +9,8 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Take produces one snapshot of sandbox id's loopback `.img`.

--- a/control-plane/internal/traefik/traefik.go
+++ b/control-plane/internal/traefik/traefik.go
@@ -48,11 +48,11 @@ func Labels(id string, ports []int, domain, visibility, entrypoint string, tls b
 	if entrypoint == "" {
 		entrypoint = "web"
 	}
-	// `sandboxed.managed=true` lets this distribution's Traefik scope its
+	// `sandboxd.managed=true` lets this distribution's Traefik scope its
 	// docker provider with a constraint so it only ever routes sandboxes
-	// it owns — important when sandboxed shares a Docker daemon with
+	// it owns — important when sandboxd shares a Docker daemon with
 	// other Traefik-labelled containers. See traefik/traefik.yml.
-	out := []string{"traefik.enable=true", "sandboxed.managed=true"}
+	out := []string{"traefik.enable=true", "sandboxd.managed=true"}
 	for _, p := range ports {
 		router := fmt.Sprintf("s-%s-%d", id, p)
 		host := fmt.Sprintf("s-%s-%d.preview.%s", id, p, domain)

--- a/control-plane/internal/traefik/traefik_test.go
+++ b/control-plane/internal/traefik/traefik_test.go
@@ -19,7 +19,7 @@ func TestLabels_SinglePort_HTTP(t *testing.T) {
 	got := Labels("nx", []int{3000}, "localhost", "public", "web", false)
 	want := []string{
 		"traefik.enable=true",
-		"sandboxed.managed=true",
+		"sandboxd.managed=true",
 		"traefik.http.routers.s-nx-3000.rule=Host(`s-nx-3000.preview.localhost`)",
 		"traefik.http.routers.s-nx-3000.entrypoints=web",
 		"traefik.http.routers.s-nx-3000.priority=100",
@@ -35,7 +35,7 @@ func TestLabels_SinglePort_TLS(t *testing.T) {
 	got := Labels("nx", []int{3000}, "example.com", "public", "websecure", true)
 	want := []string{
 		"traefik.enable=true",
-		"sandboxed.managed=true",
+		"sandboxd.managed=true",
 		"traefik.http.routers.s-nx-3000.rule=Host(`s-nx-3000.preview.example.com`)",
 		"traefik.http.routers.s-nx-3000.entrypoints=websecure",
 		"traefik.http.routers.s-nx-3000.priority=100",

--- a/control-plane/internal/wake/admit.go
+++ b/control-plane/internal/wake/admit.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/sandboxed/control-plane/internal/reaper"
+	"github.com/sandboxd/control-plane/internal/reaper"
 )
 
 // AdmitConfig parametrises the admission function. Defaults mirror

--- a/control-plane/internal/wake/handler.go
+++ b/control-plane/internal/wake/handler.go
@@ -14,14 +14,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sandboxed/control-plane/internal/audit"
-	"github.com/sandboxed/control-plane/internal/auth"
-	"github.com/sandboxed/control-plane/internal/cgroup"
-	"github.com/sandboxed/control-plane/internal/docker"
-	"github.com/sandboxed/control-plane/internal/egress"
-	"github.com/sandboxed/control-plane/internal/idlock"
-	"github.com/sandboxed/control-plane/internal/metrics"
-	"github.com/sandboxed/control-plane/internal/store"
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/cgroup"
+	"github.com/sandboxd/control-plane/internal/docker"
+	"github.com/sandboxd/control-plane/internal/egress"
+	"github.com/sandboxd/control-plane/internal/idlock"
+	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/store"
 )
 
 // Handler implements both HTML and JSON wake entry points.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# sandboxed — full stack, runs entirely on Docker.
+# sandboxd — full stack, runs entirely on Docker.
 #
 #   traefik   edge router; turns each sandbox's labels into an HTTPS-or-
 #             HTTP preview route and wakes stopped sandboxes on demand.
@@ -8,16 +8,16 @@
 #             reapers and the wake path.
 #
 # Per-sandbox containers are NOT services here — sandboxd launches them
-# at runtime from the prebuilt ${SANDBOXED_IMAGE}. They join the same
-# ${SANDBOXED_NETWORK} so Traefik can route to them.
+# at runtime from the prebuilt ${SANDBOXD_IMAGE}. They join the same
+# ${SANDBOXD_NETWORK} so Traefik can route to them.
 #
 # Everything is parameterised from .env (see .env.example).
 
 networks:
-  sandboxed_net:
+  sandboxd_net:
     # Explicit name so the literal string also works as the --network
     # value sandboxd passes to `docker run` for each sandbox.
-    name: ${SANDBOXED_NETWORK:-sandboxed_net}
+    name: ${SANDBOXD_NETWORK:-sandboxd_net}
 
 services:
   traefik:
@@ -43,46 +43,46 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/dynamic:/etc/traefik/dynamic:ro
-      - ${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}:${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}
+      - ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}:${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}
     networks:
-      - sandboxed_net
+      - sandboxd_net
 
   sandboxd:
     build:
       context: ./control-plane
-    image: sandboxed-control-plane:1.0.0
+    image: sandboxd-control-plane:1.0.0
     restart: unless-stopped
     userns_mode: "host"  # see traefik above
     # Reachable on the internal network as http://sandboxd:9000. The API
     # is also published to the loopback for local use / the upstream
-    # backend; change SANDBOXED_API_BIND in .env if 127.0.0.1:9090 clashes.
+    # backend; change SANDBOXD_API_BIND in .env if 127.0.0.1:9090 clashes.
     ports:
-      - "${SANDBOXED_API_BIND:-127.0.0.1:9090}:9000"
+      - "${SANDBOXD_API_BIND:-127.0.0.1:9090}:9000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Symmetric data-dir mount: the path sandboxd writes is ALSO a valid
       # host path, so the sibling `docker run -v <workspace>:/home/sandbox`
       # resolves on the host daemon. Do not change one side without the other.
-      - ${SANDBOXED_DATA_DIR:-/var/lib/sandboxed}:${SANDBOXED_DATA_DIR:-/var/lib/sandboxed}
-      - ${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}:${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}
+      - ${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}:${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}
+      - ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}:${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}
     environment:
       # --- core ---
       PREVIEW_DOMAIN: ${PREVIEW_DOMAIN:-localhost}
-      SANDBOXD_IMAGE: ${SANDBOXED_IMAGE:-sandboxed-base:1.0.0}
-      SANDBOXED_NETWORK: ${SANDBOXED_NETWORK:-sandboxed_net}
-      SANDBOXED_USERNS: ${SANDBOXED_USERNS:-host}
-      SANDBOXED_DATA_DIR: ${SANDBOXED_DATA_DIR:-/var/lib/sandboxed}
-      SANDBOXED_LOG_DIR: ${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}
-      SANDBOXD_ACCESS_LOG: ${SANDBOXED_LOG_DIR:-/var/lib/sandboxed/log}/traefik-access.log
+      SANDBOXD_IMAGE: ${SANDBOXD_IMAGE:-sandboxd-base:1.0.0}
+      SANDBOXD_NETWORK: ${SANDBOXD_NETWORK:-sandboxd_net}
+      SANDBOXD_USERNS: ${SANDBOXD_USERNS:-host}
+      SANDBOXD_DATA_DIR: ${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}
+      SANDBOXD_LOG_DIR: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}
+      SANDBOXD_ACCESS_LOG: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}/traefik-access.log
       # --- routing (HTTP by default) ---
       PREVIEW_ENTRYPOINT: ${PREVIEW_ENTRYPOINT:-web}
       PREVIEW_TLS: ${PREVIEW_TLS:-false}
       # --- portability toggles ---
-      SANDBOXED_SET_MEMORY_HIGH: ${SANDBOXED_SET_MEMORY_HIGH:-false}
+      SANDBOXD_SET_MEMORY_HIGH: ${SANDBOXD_SET_MEMORY_HIGH:-false}
       # --- auth (open by default for local use; set tokens for prod) ---
       SANDBOXD_API_AUTH_DISABLED: ${SANDBOXD_API_AUTH_DISABLED:-true}
       SANDBOXD_API_TOKENS: ${SANDBOXD_API_TOKENS:-}
       # --- idle lifecycle (override if you like) ---
       SANDBOXD_IDLE_THRESHOLD_SECONDS: ${SANDBOXD_IDLE_THRESHOLD_SECONDS:-2100}
     networks:
-      - sandboxed_net
+      - sandboxd_net

--- a/image/build.sh
+++ b/image/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # image/build.sh [version]
 #
-# Build the sandboxed base image. Multi-stage: stage 1 compiles the
+# Build the sandboxd base image. Multi-stage: stage 1 compiles the
 # `runtimed` supervisor from ../control-plane (so the host needs only
 # Docker, not Go); stage 2 is the Debian-slim runtime image with the
 # language toolchains baked in.
@@ -14,7 +14,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSION="${1:-1.0.0}"
-IMAGE="${SANDBOXED_IMAGE:-sandboxed-base:${VERSION}}"
+IMAGE="${SANDBOXD_IMAGE:-sandboxd-base:${VERSION}}"
 
 # `docker` may need sudo on some hosts; honour a DOCKER override that can
 # include arguments (e.g. DOCKER="sudo docker").

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# sandboxed — one-click installer.
+# sandboxd — one-click installer.
 #
 #   curl -fsSL .../install.sh | bash      # or: ./install.sh
 #
@@ -47,7 +47,7 @@ else
   die "Docker Compose not found. Install the Compose plugin (docker compose)."
 fi
 
-bold "sandboxed — installer"
+bold "sandboxd — installer"
 ok "Docker:  $($DOCKER version --format '{{.Server.Version}}' 2>/dev/null || echo present)"
 ok "Compose: $($COMPOSE version --short 2>/dev/null || echo present)"
 
@@ -61,9 +61,9 @@ fi
 
 # Load .env so we know the data dir / image tag to use below.
 set -a; . ./.env; set +a
-DATA_DIR="${SANDBOXED_DATA_DIR:-/var/lib/sandboxed}"
-LOG_DIR="${SANDBOXED_LOG_DIR:-$DATA_DIR/log}"
-BASE_IMAGE="${SANDBOXED_IMAGE:-sandboxed-base:1.0.0}"
+DATA_DIR="${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}"
+LOG_DIR="${SANDBOXD_LOG_DIR:-$DATA_DIR/log}"
+BASE_IMAGE="${SANDBOXD_IMAGE:-sandboxd-base:1.0.0}"
 
 # ── data dir ─────────────────────────────────────────────────────────
 # Create it (sudo if we don't own the parent). Workspaces + SQLite + the
@@ -81,7 +81,7 @@ ok "data dir ready: $DATA_DIR"
 
 # ── build the sandbox base image ─────────────────────────────────────
 bold "Building the sandbox base image (one-time, a few minutes)…"
-DOCKER="$DOCKER" SANDBOXED_IMAGE="$BASE_IMAGE" bash image/build.sh "${BASE_IMAGE##*:}"
+DOCKER="$DOCKER" SANDBOXD_IMAGE="$BASE_IMAGE" bash image/build.sh "${BASE_IMAGE##*:}"
 ok "base image: $BASE_IMAGE"
 
 # ── build + start the stack ──────────────────────────────────────────
@@ -91,13 +91,13 @@ $COMPOSE up -d
 ok "stack is up"
 
 # ── summary ──────────────────────────────────────────────────────────
-API_BIND="${SANDBOXED_API_BIND:-127.0.0.1:9090}"
+API_BIND="${SANDBOXD_API_BIND:-127.0.0.1:9090}"
 HTTP_PORT="${HTTP_PORT:-80}"
 PREVIEW_DOMAIN="${PREVIEW_DOMAIN:-localhost}"
 PORTSUFFIX=""; [ "$HTTP_PORT" != "80" ] && PORTSUFFIX=":$HTTP_PORT"
 
 echo
-bold "sandboxed is running 🎉"
+bold "sandboxd is running 🎉"
 cat <<EOF
 
   Control-plane API : http://${API_BIND}

--- a/traefik/dynamic/api.yml
+++ b/traefik/dynamic/api.yml
@@ -1,7 +1,7 @@
 # Optional: expose the sandboxd control-plane API through Traefik at
 #   http://api.preview.<domain>
 # (e.g. http://api.preview.localhost). The API is also published on the
-# loopback by the compose file (SANDBOXED_API_BIND, default
+# loopback by the compose file (SANDBOXD_API_BIND, default
 # 127.0.0.1:9090) — this router is for reaching it over the edge.
 #
 # sandboxd's own auth applies: when SANDBOXD_API_AUTH_DISABLED=false and

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -1,4 +1,4 @@
-# sandboxed — Traefik v3 static configuration (OSS / docker-native).
+# sandboxd — Traefik v3 static configuration (OSS / docker-native).
 #
 # Plain HTTP by default: browsers resolve any *.localhost name to
 # 127.0.0.1, so preview URLs like
@@ -26,13 +26,13 @@ providers:
     endpoint: "unix:///var/run/docker.sock"
     exposedByDefault: false
     # Only route containers this distribution manages. sandboxd emits the
-    # `sandboxed.managed=true` label on every sandbox it creates, so this
+    # `sandboxd.managed=true` label on every sandbox it creates, so this
     # Traefik never touches unrelated containers that happen to share the
     # daemon (including another Traefik's, or a different stack's).
-    constraints: "Label(`sandboxed.managed`,`true`)"
+    constraints: "Label(`sandboxd.managed`,`true`)"
     # The network sandboxes (and this Traefik) share. Must match
-    # SANDBOXED_NETWORK / the compose network name.
-    network: sandboxed_net
+    # SANDBOXD_NETWORK / the compose network name.
+    network: sandboxd_net
   file:
     directory: /etc/traefik/dynamic
     watch: true
@@ -44,7 +44,7 @@ log:
 accessLog:
   # Written to a path bind-mounted into BOTH traefik and sandboxd so the
   # control plane's tailer can read RequestHost lines and keep sandboxes
-  # marked active. Must match SANDBOXED_LOG_DIR / SANDBOXD_ACCESS_LOG.
+  # marked active. Must match SANDBOXD_LOG_DIR / SANDBOXD_ACCESS_LOG.
   filePath: /var/lib/sandboxed/log/traefik-access.log
   format: json
   bufferingSize: 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# sandboxed — uninstaller.
+# sandboxd — uninstaller.
 #
 #   ./uninstall.sh                 stop the stack + remove all sandboxes + network
 #   ./uninstall.sh --images        also remove the built Docker images
@@ -8,9 +8,9 @@
 #   ./uninstall.sh --all           --images + --data (full removal)
 #   ./uninstall.sh --all --yes     full removal, no confirmation prompt
 #
-# Safe by default: it removes only what sandboxed created (containers
-# carrying the `sandboxed.managed=true` label, plus the compose stack and
-# network). Your workspaces under SANDBOXED_DATA_DIR are KEPT unless you
+# Safe by default: it removes only what sandboxd created (containers
+# carrying the `sandboxd.managed=true` label, plus the compose stack and
+# network). Your workspaces under SANDBOXD_DATA_DIR are KEPT unless you
 # pass --data / --all. It never touches the git checkout itself.
 
 set -euo pipefail
@@ -44,11 +44,11 @@ else COMPOSE=""; fi
 
 # Load .env (if present) for the data dir / image names.
 [ -f .env ] && { set -a; . ./.env; set +a; }
-DATA_DIR="${SANDBOXED_DATA_DIR:-/var/lib/sandboxed}"
-BASE_IMAGE="${SANDBOXED_IMAGE:-sandboxed-base:1.0.0}"
-CP_IMAGE="sandboxed-control-plane:1.0.0"
+DATA_DIR="${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}"
+BASE_IMAGE="${SANDBOXD_IMAGE:-sandboxd-base:1.0.0}"
+CP_IMAGE="sandboxd-control-plane:1.0.0"
 
-bold "sandboxed — uninstall"
+bold "sandboxd — uninstall"
 
 # 1. Stop + remove the compose stack (traefik + sandboxd) and its network.
 if [ -n "$COMPOSE" ]; then
@@ -56,8 +56,8 @@ if [ -n "$COMPOSE" ]; then
 fi
 
 # 2. Remove every sandbox container this stack created. Scoped precisely
-#    by the sandboxed.managed label so nothing else on the host is touched.
-SANDBOXES=$($DOCKER ps -aq --filter "label=sandboxed.managed=true" 2>/dev/null || true)
+#    by the sandboxd.managed label so nothing else on the host is touched.
+SANDBOXES=$($DOCKER ps -aq --filter "label=sandboxd.managed=true" 2>/dev/null || true)
 if [ -n "$SANDBOXES" ]; then
   echo "$SANDBOXES" | xargs -r $DOCKER rm -f >/dev/null
   ok "removed sandbox containers: $(echo "$SANDBOXES" | wc -l | tr -d ' ')"
@@ -66,7 +66,7 @@ else
 fi
 
 # 3. Remove the network if it lingers.
-NET="${SANDBOXED_NETWORK:-sandboxed_net}"
+NET="${SANDBOXD_NETWORK:-sandboxd_net}"
 $DOCKER network rm "$NET" >/dev/null 2>&1 && ok "removed network $NET" || true
 
 # 4. Optionally remove images.


### PR DESCRIPTION
﻿## What

Standardizes the project naming on **`sandboxd`** following the repo rename. Closes #8.

Before this, the name was spelled three ways (`sandboxed` / `sandboxd` / `sandboxes`) and the environment-variable prefix was split between `SANDBOXED_` and `SANDBOXD_` ? sometimes in the same file.

## Changes

- **Env vars:** the 9 `SANDBOXED_*` vars renamed to `SANDBOXD_*` (`.env.example`, `docker-compose.yml`, `install.sh`, `uninstall.sh`, `image/build.sh`, Go string literals). Drops the now-redundant `SANDBOXD_IMAGE: ${SANDBOXED_IMAGE:-...}` compose shim.
- **Images / network / label:** `sandboxed-base` ? `sandboxd-base`, `sandboxed-control-plane` ? `sandboxd-control-plane`, network `sandboxed_net` ? `sandboxd_net`, Docker label `sandboxed.managed` ? `sandboxd.managed` (label emitter, Traefik constraint, uninstall filter, and tests kept in sync).
- **Go module path:** `github.com/sandboxed/control-plane` ? `github.com/sandboxd/control-plane` (go.mod + all imports).
- **Clone URL:** README `tastyeffectco/sandboxes` ? `tastyeffectco/sandboxd`.
- **Prose:** brand swept across `README.md`, `ARCHITECTURE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `LICENSE`.

Pure rename: **231 insertions / 231 deletions**, no logic changes.

## Out of scope (follow-up)

On-disk paths `/var/lib/sandboxed`, `/var/log/sandboxed`, `/etc/sandboxed` are intentionally **left as-is** (not in the issue checklist) to avoid relocating persistent data. A look-around in the rename script preserved them.

## Breaking changes / migration

This is a breaking change for existing deployments (pre-1.0):
- Rename `SANDBOXED_*` ? `SANDBOXD_*` in your `.env`.
- Rebuild images (`sandboxd-base`, `sandboxd-control-plane`); the network and managed-label change, so existing sandboxes are recreated on the next `docker compose up`.

## Verification

- `git grep` confirms zero remaining `SANDBOXED_`, `github.com/sandboxed`, `sandboxed-base`, `sandboxed-control-plane`, `sandboxed_net`, `sandboxed.managed`, or `tastyeffectco/sandboxes`.
- No Go toolchain on the authoring machine, so `go build`/`go test` were **not** run locally ? please let CI confirm the module-path rename compiles.

?? Generated with [Claude Code](https://claude.com/claude-code)
