### PR TITLE
docs: note Rancher Desktop / k3s port 80 conflict for preview URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,13 @@ PREVIEW_ENTRYPOINT=web
 PREVIEW_TLS=false
 
 # Host port Traefik listens on. Use 80 on a dedicated host; pick another
-# (e.g. 8088) if something already owns 80. Preview URLs then include it:
-#   http://s-<id>-<port>.preview.localhost:8088
+# (e.g. 8080) if something already owns 80. Preview URLs then include it:
+#   http://s-<id>-<port>.preview.localhost:8080
+#
+# macOS note — Rancher Desktop and Docker Desktop with k3s enabled bind
+# port 80 via their built-in Traefik/klipper-lb before sandboxd's Traefik
+# can claim it, so preview URLs silently 404. Use HTTP_PORT=8080 (or any
+# free port) and restart: docker compose up -d traefik
 HTTP_PORT=80
 
 # ── Images & network ─────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ from 80). The first request to a stopped sandbox **wakes it** automatically. On 
 real domain you get `https://s-<id>-3000.preview.yourdomain.com`
 (see [Production / TLS](#production--tls)).
 
+> **Rancher Desktop / Docker Desktop + k3s:** these bundle a k3s cluster whose
+> klipper-lb grabs port 80 before sandboxd's Traefik can, so preview URLs return
+> 404. Fix: set `HTTP_PORT=8080` in `.env` and run `docker compose up -d traefik`.
+> Preview URLs become `http://s-<id>-<port>.preview.localhost:8080`.
+
 > **Just want a shell, no agent?** Skip step 2 and run anything via the exec API:
 > `curl -XPOST $API/sandbox/$ID/exec -d '{"cmd":["bash","-lc","cd ~/workspace/app && python3 -m http.server 3000"]}'`
 > then open the same preview URL.


### PR DESCRIPTION
Closes #12

## Summary

- Add a callout in the README next to the preview URL section explaining the Rancher Desktop / Docker Desktop + k3s port 80 conflict and the fix (`HTTP_PORT=8080`)
- Expand the `HTTP_PORT` comment in `.env.example` to explicitly name klipper-lb as the cause and give the restart command

## Root cause

Rancher Desktop (and Docker Desktop with k3s enabled) deploys a klipper-lb container that binds port 80 inside the Lima VM before sandboxd's Traefik can claim it. All preview URL requests from the host silently hit the k3s Traefik instead — sandboxd's Traefik access log shows zero host-originated traffic. The fix is one line in `.env`: `HTTP_PORT=8080`.

## Test plan

- [ ] Fresh Rancher Desktop setup: follow quickstart with `HTTP_PORT=8080`, confirm preview URL works at `:8080`
- [ ] Dedicated Linux host: default `HTTP_PORT=80` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)