### PR TITLE
feat: per-sandbox idle_policy (sleep / always_on)

### DIFF
--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -68,6 +68,10 @@ type createReq struct {
 	// `docker run --env`; keys must be non-empty and free of '=' and
 	// newlines.
 	Env map[string]string `json:"env,omitempty"`
+	// IdlePolicy controls how the idle reaper treats this sandbox.
+	// 'sleep' (default): idle-stop after the global threshold, wake-on-request.
+	// 'always_on': never idle-stopped (for background workers, bots, etc.).
+	IdlePolicy string `json:"idle_policy,omitempty"`
 }
 
 type sandboxResp struct {
@@ -99,6 +103,7 @@ type sandboxResp struct {
 	ExternalProjectID   string `json:"external_project_id,omitempty"`
 	ExternalWorkspaceID string `json:"external_workspace_id,omitempty"`
 	Visibility          string `json:"visibility"`
+	IdlePolicy          string `json:"idle_policy"`
 }
 
 type getResp struct {
@@ -166,6 +171,10 @@ func toRespRow(sb *store.Sandbox) sandboxResp {
 	r.Visibility = sb.Visibility
 	if r.Visibility == "" {
 		r.Visibility = "public"
+	}
+	r.IdlePolicy = sb.IdlePolicy
+	if r.IdlePolicy == "" {
+		r.IdlePolicy = "sleep"
 	}
 	return r
 }
@@ -325,6 +334,14 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "visibility must be 'public' or 'private'")
 		return
 	}
+	idlePolicy := req.IdlePolicy
+	if idlePolicy == "" {
+		idlePolicy = "sleep"
+	}
+	if idlePolicy != "sleep" && idlePolicy != "always_on" {
+		writeErr(w, http.StatusBadRequest, "idle_policy must be 'sleep' or 'always_on'")
+		return
+	}
 	if req.GitRemoteURL != "" && !strings.HasPrefix(req.GitRemoteURL, "https://") {
 		writeErr(w, http.StatusBadRequest, "git_remote_url must be an https:// URL")
 		return
@@ -431,6 +448,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		MemoryHigh:          req.MemoryHigh,
 		Ports:               req.Ports,
 		Visibility:          visibility,
+		IdlePolicy:          idlePolicy,
 		ExternalUserID:      nullStr(req.External.UserID),
 		ExternalProjectID:   nullStr(req.External.ProjectID),
 		ExternalWorkspaceID: nullStr(req.External.WorkspaceID),

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -68,25 +68,27 @@ type createReq struct {
 	// `docker run --env`; keys must be non-empty and free of '=' and
 	// newlines.
 	Env map[string]string `json:"env,omitempty"`
-	// IdlePolicy controls how the idle reaper treats this sandbox.
-	// 'sleep' (default): idle-stop after the global threshold, wake-on-request.
-	// 'always_on': never idle-stopped (for background workers, bots, etc.).
+	// IdlePolicy controls how the reapers treat this sandbox.
+	//   'sleep' (default): idle-stopped after the global threshold; wakes on request.
+	//   'always_on': never idle-stopped, and exempt from moderate memory-pressure
+	//   reaping. NOTE: still stoppable under critical host pressure (<5% mem
+	//   available), and not auto-restarted if stopped.
 	IdlePolicy string `json:"idle_policy,omitempty"`
 }
 
 type sandboxResp struct {
-	ID            string  `json:"id"`
-	Status        string  `json:"status"`
-	Image         string  `json:"image"`
-	WorkspaceImg  string  `json:"workspace_img"`
-	WorkspaceMnt  string  `json:"workspace_mnt"`
-	ContainerID   string  `json:"container_id,omitempty"`
-	CgroupPath    string  `json:"cgroup_path,omitempty"`
-	MemoryHigh    string  `json:"memory_high"`
-	ErrorMessage  string  `json:"error_message,omitempty"`
-	Ports         []int   `json:"ports"`
-	CreatedAt     string  `json:"created_at"`
-	UpdatedAt     string  `json:"updated_at"`
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	Image        string `json:"image"`
+	WorkspaceImg string `json:"workspace_img"`
+	WorkspaceMnt string `json:"workspace_mnt"`
+	ContainerID  string `json:"container_id,omitempty"`
+	CgroupPath   string `json:"cgroup_path,omitempty"`
+	MemoryHigh   string `json:"memory_high"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	Ports        []int  `json:"ports"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 	// Phase 5 — surface the activity columns so the roadmap §Validation
 	// V2/V3 expressions (`jq .row.last_active_at`, `jq .row.status`)
 	// work directly. last_active_at and stopped_at are unix seconds;

--- a/control-plane/internal/reaper/idle.go
+++ b/control-plane/internal/reaper/idle.go
@@ -34,19 +34,19 @@ import (
 // IdleConfig captures the env-tunable knobs from roadmap §12. Defaults
 // come from CLAUDE.md "Idle lifecycle".
 type IdleConfig struct {
-	Threshold     time.Duration // SANDBOXD_IDLE_THRESHOLD_SECONDS (600s)
-	Interval      time.Duration // SANDBOXD_IDLE_REAP_INTERVAL_SECONDS (30s)
-	WakeGrace     time.Duration // SANDBOXD_WAKE_GRACE_SECONDS (60s) — post-WS/SSE-disconnect grace
+	Threshold time.Duration // SANDBOXD_IDLE_THRESHOLD_SECONDS (600s)
+	Interval  time.Duration // SANDBOXD_IDLE_REAP_INTERVAL_SECONDS (30s)
+	WakeGrace time.Duration // SANDBOXD_WAKE_GRACE_SECONDS (60s) — post-WS/SSE-disconnect grace
 }
 
 // Idle is the goroutine.
 type Idle struct {
-	Cfg    IdleConfig
-	Store  *store.Store
-	Docker *docker.Client
+	Cfg      IdleConfig
+	Store    *store.Store
+	Docker   *docker.Client
 	Inflight *activity.InflightExec
-	Egress *egress.Manager // Phase 6 — nil-safe
-	Log    *slog.Logger
+	Egress   *egress.Manager // Phase 6 — nil-safe
+	Log      *slog.Logger
 }
 
 // Run blocks until ctx is cancelled. A zero or negative Interval

--- a/control-plane/internal/reaper/idle.go
+++ b/control-plane/internal/reaper/idle.go
@@ -88,6 +88,10 @@ func (i *Idle) tick(ctx context.Context) error {
 		return fmt.Errorf("list idle candidates: %w", err)
 	}
 	for _, sb := range candidates {
+		// Skip rule 0: always_on policy
+		if sb.IdlePolicy == "always_on" {
+			continue
+		}
 		// Skip rule 1: in-flight exec.
 		if i.Inflight != nil && i.Inflight.Active(sb.ID) {
 			continue

--- a/control-plane/internal/reaper/pressure.go
+++ b/control-plane/internal/reaper/pressure.go
@@ -16,10 +16,10 @@ import (
 // PressureConfig captures the env-tunable knobs from roadmap §12.
 // Defaults come from CLAUDE.md "Host memory pressure reaper".
 type PressureConfig struct {
-	Interval     time.Duration // SANDBOXD_PRESSURE_INTERVAL_SECONDS (10s)
-	HeadroomPct  float64       // SANDBOXD_MEM_HEADROOM_PCT          (15)
-	RefuseWakesPct float64     // SANDBOXD_MEM_REFUSE_WAKES_PCT      (10)
-	EmergencyPct float64       // SANDBOXD_MEM_EMERGENCY_PCT         (5)
+	Interval       time.Duration // SANDBOXD_PRESSURE_INTERVAL_SECONDS (10s)
+	HeadroomPct    float64       // SANDBOXD_MEM_HEADROOM_PCT          (15)
+	RefuseWakesPct float64       // SANDBOXD_MEM_REFUSE_WAKES_PCT      (10)
+	EmergencyPct   float64       // SANDBOXD_MEM_EMERGENCY_PCT         (5)
 }
 
 // Pressure is the goroutine.
@@ -29,7 +29,7 @@ type Pressure struct {
 	Docker   *docker.Client
 	Inflight *activity.InflightExec
 	Egress   *egress.Manager // Phase 6 — nil-safe
-	Refused  *atomic.Bool // shared with the wake admission code; set when in 5-10% or <5% band
+	Refused  *atomic.Bool    // shared with the wake admission code; set when in 5-10% or <5% band
 	Log      *slog.Logger
 }
 
@@ -129,6 +129,9 @@ func (p *Pressure) stopOldestIdle(ctx context.Context, band string, availPct flo
 	now := time.Now().UTC()
 	// cutoff=now means "any row not currently being marked active";
 	// the skip rules below handle inflight exec / keepalive.
+	// always_on sandboxes are excluded by ListIdleCandidates' SQL filter, so
+	// moderate-pressure reaping skips them by design. The emergency path
+	// (stopHeaviestRSS) intentionally ignores idle_policy to save the host.
 	candidates, err := p.Store.ListIdleCandidates(ctx, now)
 	if err != nil {
 		p.Log.Warn("pressure reaper: list idle candidates failed", "err", err.Error())

--- a/control-plane/internal/store/idle_policy_test.go
+++ b/control-plane/internal/store/idle_policy_test.go
@@ -21,13 +21,13 @@ func openTestStore(t *testing.T) *Store {
 
 func minimalSandbox(id, idlePolicy string) *Sandbox {
 	return &Sandbox{
-		ID:           id,
-		Status:       "running",
-		Image:        "sandboxd-base:1.0.0",
-		WorkspaceImg: "/workspaces/" + id + ".img",
-		WorkspaceMnt: "/workspaces/" + id + ".mnt",
-		MemoryHigh:   "4G",
-		IdlePolicy:   idlePolicy,
+		ID:             id,
+		Status:         "running",
+		Image:          "sandboxd-base:1.0.0",
+		WorkspaceImg:   "/workspaces/" + id + ".img",
+		WorkspaceMnt:   "/workspaces/" + id + ".mnt",
+		MemoryHigh:     "4G",
+		IdlePolicy:     idlePolicy,
 		ExternalUserID: sql.NullString{String: "u1", Valid: true},
 	}
 }
@@ -140,5 +140,49 @@ func TestIdlePolicyInListAndListFiltered(t *testing.T) {
 		if s.ID == id && s.IdlePolicy != "always_on" {
 			t.Errorf("ListFiltered: IdlePolicy = %q, want always_on", s.IdlePolicy)
 		}
+	}
+}
+
+func TestListIdleCandidatesExcludesAlwaysOnAtPressureCutoff(t *testing.T) {
+	// The pressure reaper calls ListIdleCandidates(now); a cutoff of "now"
+	// makes every running sandbox a candidate. always_on must STILL be
+	// excluded so moderate memory pressure does not stop it. (The emergency
+	// path is separate and intentionally ignores idle_policy.)
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	sleepID, alwaysOnID := "pressure-sleep", "pressure-always-on"
+	if err := st.Create(ctx, minimalSandbox(sleepID, "sleep")); err != nil {
+		t.Fatalf("Create sleep: %v", err)
+	}
+	if err := st.Create(ctx, minimalSandbox(alwaysOnID, "always_on")); err != nil {
+		t.Fatalf("Create always_on: %v", err)
+	}
+	recent := time.Now().UTC().Add(-1 * time.Second)
+	if err := st.BumpLastActive(ctx, sleepID, recent); err != nil {
+		t.Fatalf("BumpLastActive sleep: %v", err)
+	}
+	if err := st.BumpLastActive(ctx, alwaysOnID, recent); err != nil {
+		t.Fatalf("BumpLastActive always_on: %v", err)
+	}
+
+	candidates, err := st.ListIdleCandidates(ctx, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ListIdleCandidates: %v", err)
+	}
+	var sawSleep, sawAlwaysOn bool
+	for _, sb := range candidates {
+		switch sb.ID {
+		case sleepID:
+			sawSleep = true
+		case alwaysOnID:
+			sawAlwaysOn = true
+		}
+	}
+	if sawAlwaysOn {
+		t.Errorf("always_on sandbox returned at pressure cutoff — must be excluded")
+	}
+	if !sawSleep {
+		t.Errorf("sleep sandbox not returned at pressure cutoff — must be a candidate")
 	}
 }

--- a/control-plane/internal/store/idle_policy_test.go
+++ b/control-plane/internal/store/idle_policy_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// openTestStore opens an in-memory SQLite store with all migrations applied.
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	ctx := context.Background()
+	st, err := Open(ctx, "file::memory:?_fk=1", "../../migrations")
+	if err != nil {
+		t.Fatalf("open test store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+func minimalSandbox(id, idlePolicy string) *Sandbox {
+	return &Sandbox{
+		ID:           id,
+		Status:       "running",
+		Image:        "sandboxd-base:1.0.0",
+		WorkspaceImg: "/workspaces/" + id + ".img",
+		WorkspaceMnt: "/workspaces/" + id + ".mnt",
+		MemoryHigh:   "4G",
+		IdlePolicy:   idlePolicy,
+		ExternalUserID: sql.NullString{String: "u1", Valid: true},
+	}
+}
+
+func TestIdlePolicyRoundTrip(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	cases := []struct{ id, policy string }{
+		{"01AAAAAAAAAAAAAAAAAAAAAAAA", "sleep"},
+		{"01BBBBBBBBBBBBBBBBBBBBBBBB", "always_on"},
+		{"01CCCCCCCCCCCCCCCCCCCCCCCC", ""},
+	}
+	for _, tc := range cases {
+		if err := st.Create(ctx, minimalSandbox(tc.id, tc.policy)); err != nil {
+			t.Fatalf("Create %s: %v", tc.id, err)
+		}
+	}
+
+	want := map[string]string{
+		"01AAAAAAAAAAAAAAAAAAAAAAAA": "sleep",
+		"01BBBBBBBBBBBBBBBBBBBBBBBB": "always_on",
+		"01CCCCCCCCCCCCCCCCCCCCCCCC": "sleep", // empty defaults to sleep
+	}
+	for id, wantPolicy := range want {
+		sb, err := st.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("Get %s: %v", id, err)
+		}
+		if sb.IdlePolicy != wantPolicy {
+			t.Errorf("id=%s: IdlePolicy = %q, want %q", id, sb.IdlePolicy, wantPolicy)
+		}
+	}
+}
+
+func TestListIdleCandidatesExcludesAlwaysOn(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	// Create a 'sleep' sandbox and an 'always_on' sandbox, both with an
+	// old last_active_at so they'd be idle candidates if policy allowed.
+	sleepID := "01DDDDDDDDDDDDDDDDDDDDDDDD"
+	alwaysOnID := "01EEEEEEEEEEEEEEEEEEEEEEEE"
+
+	if err := st.Create(ctx, minimalSandbox(sleepID, "sleep")); err != nil {
+		t.Fatalf("Create sleep sandbox: %v", err)
+	}
+	if err := st.Create(ctx, minimalSandbox(alwaysOnID, "always_on")); err != nil {
+		t.Fatalf("Create always_on sandbox: %v", err)
+	}
+
+	// Set last_active_at to 1 hour ago so both are past any reasonable threshold.
+	old := time.Now().UTC().Add(-1 * time.Hour)
+	if err := st.BumpLastActive(ctx, sleepID, old); err != nil {
+		t.Fatalf("BumpLastActive sleep: %v", err)
+	}
+	if err := st.BumpLastActive(ctx, alwaysOnID, old); err != nil {
+		t.Fatalf("BumpLastActive always_on: %v", err)
+	}
+
+	// cutoff = 5 minutes ago — both sandboxes are idle relative to this.
+	cutoff := time.Now().UTC().Add(-5 * time.Minute)
+	candidates, err := st.ListIdleCandidates(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("ListIdleCandidates: %v", err)
+	}
+
+	for _, sb := range candidates {
+		if sb.ID == alwaysOnID {
+			t.Errorf("ListIdleCandidates returned always_on sandbox %s — it should be excluded", alwaysOnID)
+		}
+	}
+
+	found := false
+	for _, sb := range candidates {
+		if sb.ID == sleepID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ListIdleCandidates did not return sleep sandbox %s — it should be a candidate", sleepID)
+	}
+}
+
+func TestIdlePolicyInListAndListFiltered(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	id := "01FFFFFFFFFFFFFFFFFFFFFFFFFFFF"[0:26]
+	sb := minimalSandbox(id, "always_on")
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	all, err := st.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, s := range all {
+		if s.ID == id && s.IdlePolicy != "always_on" {
+			t.Errorf("List: IdlePolicy = %q, want always_on", s.IdlePolicy)
+		}
+	}
+
+	filtered, err := st.ListFiltered(ctx, "u1", "")
+	if err != nil {
+		t.Fatalf("ListFiltered: %v", err)
+	}
+	for _, s := range filtered {
+		if s.ID == id && s.IdlePolicy != "always_on" {
+			t.Errorf("ListFiltered: IdlePolicy = %q, want always_on", s.IdlePolicy)
+		}
+	}
+}

--- a/control-plane/internal/store/store.go
+++ b/control-plane/internal/store/store.go
@@ -20,18 +20,18 @@ import (
 
 // Sandbox is the in-memory mirror of a `sandbox` table row.
 type Sandbox struct {
-	ID             string
-	Status         string // creating | running | stopped | error
-	Image          string
-	WorkspaceImg   string
-	WorkspaceMnt   string
-	ContainerID    sql.NullString
-	CgroupPath     sql.NullString
-	MemoryHigh     string
-	ErrorMessage   sql.NullString
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Ports          []int
+	ID           string
+	Status       string // creating | running | stopped | error
+	Image        string
+	WorkspaceImg string
+	WorkspaceMnt string
+	ContainerID  sql.NullString
+	CgroupPath   sql.NullString
+	MemoryHigh   string
+	ErrorMessage sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Ports        []int
 
 	// Phase 5 — activity / lifecycle columns (migrations/0002_activity.sql).
 	LastActiveAt   time.Time     // bumped by tailer / poller / exec / wake; zero value if never observed
@@ -71,10 +71,10 @@ type WorkspaceOwner struct {
 
 // Store wraps an open *sql.DB plus the write-loop goroutine.
 type Store struct {
-	db       *sql.DB
-	writes   chan writeOp
-	doneCh   chan struct{}
-	closeCh  chan struct{}
+	db      *sql.DB
+	writes  chan writeOp
+	doneCh  chan struct{}
+	closeCh chan struct{}
 }
 
 // Open opens the database at dsn, applies migrations, and starts the

--- a/control-plane/internal/store/store.go
+++ b/control-plane/internal/store/store.go
@@ -42,6 +42,11 @@ type Sandbox struct {
 	// (migrations/0003_container_ip.sql). NULL while stopped.
 	ContainerIP sql.NullString
 
+	// idle_policy controls the idle reaper's behaviour for this sandbox
+	// (migrations/0011_idle_policy.sql). 'sleep' (default) = idle-stop +
+	// wake-on-request; 'always_on' = never idle-stopped.
+	IdlePolicy string
+
 	// Phase 8 — external identity passthrough + visibility
 	// (migrations/0004_external_identity.sql). The external_* columns
 	// are opaque upstream identifiers sandboxd never interprets beyond
@@ -130,7 +135,8 @@ func (s *Store) Get(ctx context.Context, id string) (*Sandbox, error) {
 		       created_at, updated_at,
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
-		       external_user_id, external_project_id, external_workspace_id, visibility
+		       external_user_id, external_project_id, external_workspace_id, visibility,
+		       idle_policy
 		  FROM sandbox WHERE id = ?`, id)
 	sb, err := scanSandbox(row)
 	if err != nil {
@@ -167,7 +173,8 @@ func (s *Store) List(ctx context.Context) ([]*Sandbox, error) {
 		       created_at, updated_at,
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
-		       external_user_id, external_project_id, external_workspace_id, visibility
+		       external_user_id, external_project_id, external_workspace_id, visibility,
+		       idle_policy
 		  FROM sandbox ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
@@ -202,7 +209,8 @@ func (s *Store) ListByStatuses(ctx context.Context, statuses ...string) ([]*Sand
 	             created_at, updated_at,
 	             last_active_at, stopped_at, keepalive_until,
 	             container_ip,
-	             external_user_id, external_project_id, external_workspace_id, visibility
+	             external_user_id, external_project_id, external_workspace_id, visibility,
+	             idle_policy
 	        FROM sandbox WHERE status IN (?`
 	args := make([]any, 0, len(statuses))
 	args = append(args, statuses[0])
@@ -246,9 +254,10 @@ func (s *Store) ListIdleCandidates(ctx context.Context, cutoff time.Time) ([]*Sa
 		       created_at, updated_at,
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
-		       external_user_id, external_project_id, external_workspace_id, visibility
+		       external_user_id, external_project_id, external_workspace_id, visibility,
+		       idle_policy
 		  FROM sandbox
-		 WHERE status='running' AND last_active_at < ?
+		 WHERE status='running' AND last_active_at < ? AND idle_policy != 'always_on'
 		 ORDER BY last_active_at ASC`, cutoff.Unix())
 	if err != nil {
 		return nil, err
@@ -298,6 +307,7 @@ func scanSandbox(s scanner) (*Sandbox, error) {
 		&lastActiveUnix, &sb.StoppedAt, &sb.KeepaliveUntil,
 		&sb.ContainerIP,
 		&sb.ExternalUserID, &sb.ExternalProjectID, &sb.ExternalWorkspaceID, &sb.Visibility,
+		&sb.IdlePolicy,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -310,6 +320,9 @@ func scanSandbox(s scanner) (*Sandbox, error) {
 	if lastActiveUnix > 0 {
 		sb.LastActiveAt = time.Unix(lastActiveUnix, 0).UTC()
 	}
+	if sb.IdlePolicy == "" {
+		sb.IdlePolicy = "sleep"
+	}
 	return sb, nil
 }
 
@@ -320,7 +333,8 @@ const sandboxSelectCols = `id, status, image, workspace_img, workspace_mnt,
 	       created_at, updated_at,
 	       last_active_at, stopped_at, keepalive_until,
 	       container_ip,
-	       external_user_id, external_project_id, external_workspace_id, visibility`
+	       external_user_id, external_project_id, external_workspace_id, visibility,
+	       idle_policy`
 
 // ListFiltered returns sandbox rows filtered by external_user_id and/
 // or external_project_id. An empty string for either filter means "do

--- a/control-plane/internal/store/writer.go
+++ b/control-plane/internal/store/writer.go
@@ -76,16 +76,22 @@ func (s *Store) Create(ctx context.Context, sb *Sandbox) error {
 		if visibility == "" {
 			visibility = "public"
 		}
+		idlePolicy := sb.IdlePolicy
+		if idlePolicy == "" {
+			idlePolicy = "sleep"
+		}
 		_, err = tx.ExecContext(ctx, `
 			INSERT INTO sandbox (id, status, image, workspace_img, workspace_mnt,
 			                    container_id, cgroup_path, memory_high, error_message,
 			                    created_at, updated_at,
 			                    external_user_id, external_project_id,
-			                    external_workspace_id, visibility)
-			VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?, ?, ?, ?, ?)`,
+			                    external_workspace_id, visibility,
+			                    idle_policy)
+			VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?, ?, ?, ?, ?, ?)`,
 			sb.ID, sb.Status, sb.Image, sb.WorkspaceImg, sb.WorkspaceMnt,
 			sb.MemoryHigh, now, now,
-			sb.ExternalUserID, sb.ExternalProjectID, sb.ExternalWorkspaceID, visibility)
+			sb.ExternalUserID, sb.ExternalProjectID, sb.ExternalWorkspaceID, visibility, idlePolicy)
+
 		if err != nil {
 			if isUniqueViolation(err) {
 				return ErrConflict

--- a/control-plane/migrations/0011_idle_policy.sql
+++ b/control-plane/migrations/0011_idle_policy.sql
@@ -1,0 +1,10 @@
+-- 0011 — per-sandbox idle policy (github.com/tastyeffectco/sandboxd/issues/11).
+--
+-- idle_policy controls how the idle reaper treats this sandbox:
+--   'sleep'     — default: idle-stop after the global threshold, wake-on-request.
+--   'always_on' — never idle-stopped; the sandbox keeps running indefinitely.
+--
+-- The DEFAULT is 'sleep' so all existing rows inherit the previous behaviour
+-- with no data migration required.
+
+ALTER TABLE sandbox ADD COLUMN idle_policy TEXT NOT NULL DEFAULT 'sleep';


### PR DESCRIPTION
Closes #11.

## What

Adds `idle_policy` to `POST /sandbox` so callers can opt a sandbox out of the idle reaper. Useful for background workers, queue consumers, bots, WebSocket apps, and any workload that receives no preview HTTP traffic and would otherwise be stopped after the idle threshold.

## API

```json
POST /sandbox
{"ports": [3000], "idle_policy": "always_on"}
```

`idle_policy` is `"sleep"` (default) or `"always_on"`. Omitting it is equivalent to `"sleep"` — existing behaviour is unchanged.

The field is returned on every sandbox response so callers can inspect it.

## Changes

| File | Change |
|---|---|
| `migrations/0011_idle_policy.sql` | Adds `idle_policy TEXT NOT NULL DEFAULT 'sleep'` — existing rows inherit `'sleep'` with no backfill |
| `internal/store/store.go` | `Sandbox` struct field; all SELECT queries updated; `ListIdleCandidates` adds `AND idle_policy != 'always_on'` to the SQL |
| `internal/store/writer.go` | `Create` persists `idle_policy` |
| `internal/api/handlers.go` | `createReq` + `sandboxResp` fields; validation (400 on unknown value); wired through `handleCreate` and `toRespRow` |
| `internal/reaper/idle.go` | In-memory skip rule as defence-in-depth on top of the SQL filter |
| `internal/store/idle_policy_test.go` | 3 new tests: round-trip, `ListIdleCandidates` exclusion, `List`/`ListFiltered` surface |

## Notes

- `GOOS=linux go build ./...` — clean
- `go test ./internal/store/...` — all pass (3 new + 0 regressions)
- The `manual` policy mentioned in the issue is left for a follow-up; `always_on` covers the stated use-cases