### PR TITLE
chore: gofmt the tree + add CI (gofmt/build/test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: control-plane
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: control-plane/go.mod
+
+      - name: gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-clean:"
+            echo "$unformatted"
+            echo "Run: gofmt -w ."
+            exit 1
+          fi
+
+      - name: build
+        run: go build ./...
+
+      - name: test
+        run: go test ./...

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -124,8 +124,8 @@ func main() {
 	tailerOffsetFs := filepath.Join(stateDir, "traefik-tail.offset")
 
 	// OSS docker-native toggles (default to the portable behaviour).
-	network := os.Getenv("SANDBOXD_NETWORK")              // shared docker network for Traefik routing
-	userns := envDefault("SANDBOXD_USERNS", "host")       // sandbox + seed --userns; "host" is deterministic on any daemon
+	network := os.Getenv("SANDBOXD_NETWORK")        // shared docker network for Traefik routing
+	userns := envDefault("SANDBOXD_USERNS", "host") // sandbox + seed --userns; "host" is deterministic on any daemon
 	previewEntrypoint := envDefault("PREVIEW_ENTRYPOINT", "web")
 	previewTLS := boolFromEnv("PREVIEW_TLS", false)
 	setMemoryHigh := boolFromEnv("SANDBOXD_SET_MEMORY_HIGH", false)

--- a/control-plane/internal/activity/inflight_exec.go
+++ b/control-plane/internal/activity/inflight_exec.go
@@ -7,8 +7,8 @@
 // an open WS/SSE connection, an open exec session, a recent HTTP
 // request, or an explicit keepalive_until flag. Phase 5 maps those to:
 //   - WS/SSE          → open-connection poller (or wider grace window
-//                       if no Traefik metric is verifiable; see
-//                       poller.go).
+//     if no Traefik metric is verifiable; see
+//     poller.go).
 //   - exec session    → InflightExec counter below.
 //   - HTTP request    → access-log tailer.
 //   - keepalive_until → SQLite column + idle-reaper skip rule.

--- a/control-plane/internal/activity/poller.go
+++ b/control-plane/internal/activity/poller.go
@@ -27,9 +27,10 @@ import (
 // the metric on the running host first (see
 // control-plane/README.md "Phase 5 Traefik connection metric") and
 // either:
-//   (a) supply MetricNameRE + ServiceLabel to the poller, OR
-//   (b) skip the poller entirely (the access-log tailer is the only
-//       signal; SANDBOXD_WAKE_GRACE_SECONDS is widened to compensate).
+//
+//	(a) supply MetricNameRE + ServiceLabel to the poller, OR
+//	(b) skip the poller entirely (the access-log tailer is the only
+//	    signal; SANDBOXD_WAKE_GRACE_SECONDS is widened to compensate).
 //
 // If MetricNameRE is empty the Poller logs a one-liner and exits
 // cleanly without doing any work. Run() returns nil so main.go's

--- a/control-plane/internal/activity/tailer.go
+++ b/control-plane/internal/activity/tailer.go
@@ -37,9 +37,9 @@ import (
 // can write partial trailing bytes during rotation). A line that
 // doesn't parse as JSON is logged at debug-level and skipped.
 type Tailer struct {
-	LogPath        string         // /var/log/sandboxed/traefik-access.log
-	CheckpointPath string         // /var/lib/sandboxed/state/traefik-tail.offset
-	PreviewDomain  string         // example.com
+	LogPath        string // /var/log/sandboxed/traefik-access.log
+	CheckpointPath string // /var/lib/sandboxed/state/traefik-tail.offset
+	PreviewDomain  string // example.com
 	Store          *store.Store
 	Log            *slog.Logger
 

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -80,10 +80,10 @@ type Server struct {
 
 	// Phase 5 additions — nil-safe so existing tests that build a
 	// Server without these still work.
-	Inflight       *activity.InflightExec
-	Wake           *wake.Handler
-	Admit          wake.AdmitConfig
-	KeepaliveMax   time.Duration
+	Inflight     *activity.InflightExec
+	Wake         *wake.Handler
+	Admit        wake.AdmitConfig
+	KeepaliveMax time.Duration
 
 	// Phase 6 — egress policy hook. nil-safe.
 	Egress *egress.Manager

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -71,18 +71,18 @@ type createReq struct {
 }
 
 type sandboxResp struct {
-	ID            string  `json:"id"`
-	Status        string  `json:"status"`
-	Image         string  `json:"image"`
-	WorkspaceImg  string  `json:"workspace_img"`
-	WorkspaceMnt  string  `json:"workspace_mnt"`
-	ContainerID   string  `json:"container_id,omitempty"`
-	CgroupPath    string  `json:"cgroup_path,omitempty"`
-	MemoryHigh    string  `json:"memory_high"`
-	ErrorMessage  string  `json:"error_message,omitempty"`
-	Ports         []int   `json:"ports"`
-	CreatedAt     string  `json:"created_at"`
-	UpdatedAt     string  `json:"updated_at"`
+	ID           string `json:"id"`
+	Status       string `json:"status"`
+	Image        string `json:"image"`
+	WorkspaceImg string `json:"workspace_img"`
+	WorkspaceMnt string `json:"workspace_mnt"`
+	ContainerID  string `json:"container_id,omitempty"`
+	CgroupPath   string `json:"cgroup_path,omitempty"`
+	MemoryHigh   string `json:"memory_high"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	Ports        []int  `json:"ports"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
 	// Phase 5 — surface the activity columns so the roadmap §Validation
 	// V2/V3 expressions (`jq .row.last_active_at`, `jq .row.status`)
 	// work directly. last_active_at and stopped_at are unix seconds;

--- a/control-plane/internal/docker/docker.go
+++ b/control-plane/internal/docker/docker.go
@@ -35,24 +35,24 @@ func NewClient() *Client { return &Client{Bin: "docker"} }
 // RunSpec carries every flag the Phase 2/3 sandbox-up script emitted.
 // No defaults; callers fill all of these explicitly.
 type RunSpec struct {
-	Name       string   // --name
-	Hostname   string   // --hostname
-	Network    string   // --network (OSS: shared sandboxd_net so Traefik can route)
-	Userns     string   // --userns (OSS: "host" for deterministic workspace ownership)
-	ReadOnly   bool     // --read-only
-	CapDrop    []string // --cap-drop=ALL (passed once per entry)
+	Name        string   // --name
+	Hostname    string   // --hostname
+	Network     string   // --network (OSS: shared sandboxd_net so Traefik can route)
+	Userns      string   // --userns (OSS: "host" for deterministic workspace ownership)
+	ReadOnly    bool     // --read-only
+	CapDrop     []string // --cap-drop=ALL (passed once per entry)
 	SecurityOpt []string // --security-opt=no-new-privileges
-	CPUShares  int      // --cpu-shares=100
-	Memory     string   // --memory=10g
-	MemorySwap string   // --memory-swap=10g
-	PidsLimit  int      // --pids-limit=1024
-	Ulimits    []string // --ulimit nofile=65536:65536
-	Tmpfs      []string // --tmpfs /tmp:size=512m   (one --tmpfs flag per entry)
-	Env        []string // --env KEY=VAL   (one --env flag per entry)
-	Volumes    []string // -v <host>:<container>[:opts]
-	Labels     []string // --label key=value
-	Image      string   // last positional
-	Cmd        []string // optional CMD override
+	CPUShares   int      // --cpu-shares=100
+	Memory      string   // --memory=10g
+	MemorySwap  string   // --memory-swap=10g
+	PidsLimit   int      // --pids-limit=1024
+	Ulimits     []string // --ulimit nofile=65536:65536
+	Tmpfs       []string // --tmpfs /tmp:size=512m   (one --tmpfs flag per entry)
+	Env         []string // --env KEY=VAL   (one --env flag per entry)
+	Volumes     []string // -v <host>:<container>[:opts]
+	Labels      []string // --label key=value
+	Image       string   // last positional
+	Cmd         []string // optional CMD override
 }
 
 // Run starts the container detached and returns its 12-char short ID.
@@ -180,9 +180,11 @@ func (cj *ContainerJSON) BridgeIP() string {
 // Inspect returns the parsed JSON for a container, or ErrNotFound.
 // The "not found" detection uses a CASE-INSENSITIVE substring match
 // because docker's exact wording varies by version and locale:
-//   "Error response from daemon: No such object: s-..."   (older / some)
-//   "Error: no such object: s-..."                         (current)
-//   "Error response from daemon: no such container: s-..." (legacy)
+//
+//	"Error response from daemon: No such object: s-..."   (older / some)
+//	"Error: no such object: s-..."                         (current)
+//	"Error response from daemon: no such container: s-..." (legacy)
+//
 // The original Phase 4 draft used case-sensitive matches and missed
 // the lowercase 'no such object' variant Docker emitted on this host,
 // causing the reconciler's V6 path to mis-handle missing containers.

--- a/control-plane/internal/egress/collector.go
+++ b/control-plane/internal/egress/collector.go
@@ -30,9 +30,9 @@ import (
 // `sandboxd_egress_log_lag_seconds` and journald's own ring buffer
 // caps the damage.
 type Collector struct {
-	Manager  *Manager
-	LogDir   string // /var/log/sandboxed/egress
-	Log      *slog.Logger
+	Manager *Manager
+	LogDir  string // /var/log/sandboxed/egress
+	Log     *slog.Logger
 
 	// JournalctlArgs lets tests inject a fake binary; production
 	// path uses the default ("journalctl", "-k", "-f", "-o", "json",
@@ -46,8 +46,9 @@ type Collector struct {
 
 // kernelMsgRE pulls the fields we care about out of the iptables /
 // nftables kernel log line. Reference shape from the roadmap §7:
-//   sandbox-egress IN=docker0 OUT=ens3 MAC=... SRC=172.17.0.5
-//   DST=140.82.121.4 LEN=60 ... PROTO=TCP SPT=44782 DPT=443 ... SYN
+//
+//	sandbox-egress IN=docker0 OUT=ens3 MAC=... SRC=172.17.0.5
+//	DST=140.82.121.4 LEN=60 ... PROTO=TCP SPT=44782 DPT=443 ... SYN
 //
 // We pull SRC, DST, DPT.
 var (
@@ -110,18 +111,18 @@ func (c *Collector) runOnce(ctx context.Context) error {
 // journalEntry is the slim subset of `journalctl -o json` we read.
 // REALTIME timestamps are microseconds since epoch (systemd convention).
 type journalEntry struct {
-	Message            string `json:"MESSAGE"`
-	RealtimeTimestamp  string `json:"__REALTIME_TIMESTAMP"`
+	Message           string `json:"MESSAGE"`
+	RealtimeTimestamp string `json:"__REALTIME_TIMESTAMP"`
 }
 
 // egressLine is the JSON shape we write to disk. roadmap §7 Stage B.
 type egressLine struct {
-	TS         int64  `json:"ts"`
-	SandboxID  string `json:"sandbox_id"`
-	SrcIP      string `json:"src_ip"`
-	DstIP      string `json:"dst_ip"`
-	DstPort    int    `json:"dst_port"`
-	Event      string `json:"event"`
+	TS        int64  `json:"ts"`
+	SandboxID string `json:"sandbox_id"`
+	SrcIP     string `json:"src_ip"`
+	DstIP     string `json:"dst_ip"`
+	DstPort   int    `json:"dst_port"`
+	Event     string `json:"event"`
 }
 
 func (c *Collector) consume(ctx context.Context, r io.Reader) error {
@@ -247,8 +248,8 @@ type DropPoller struct {
 	Interval time.Duration
 	Log      *slog.Logger
 
-	mu    sync.Mutex
-	prev  map[string]uint64 // reason -> packets
+	mu   sync.Mutex
+	prev map[string]uint64 // reason -> packets
 }
 
 // Run blocks until ctx is cancelled. Interval<=0 → defaults to 30s.

--- a/control-plane/internal/egress/nftables.go
+++ b/control-plane/internal/egress/nftables.go
@@ -143,9 +143,12 @@ type DropCounter struct {
 // sandbox_platform table whose comment maps to a known reason.
 //
 // nft -j output for a rule with a counter looks like:
-//   {"rule": {"expr": [...], "comment": "block abuse list", ...}}
+//
+//	{"rule": {"expr": [...], "comment": "block abuse list", ...}}
+//
 // where the expr contains a counter element:
-//   {"counter": {"packets": 123, "bytes": 4567}}
+//
+//	{"counter": {"packets": 123, "bytes": 4567}}
 //
 // We walk every rule, extract (comment, counter) where present.
 func (n *Nft) readDropCounters(ctx context.Context) ([]DropCounter, error) {

--- a/control-plane/internal/reaper/idle.go
+++ b/control-plane/internal/reaper/idle.go
@@ -34,19 +34,19 @@ import (
 // IdleConfig captures the env-tunable knobs from roadmap §12. Defaults
 // come from CLAUDE.md "Idle lifecycle".
 type IdleConfig struct {
-	Threshold     time.Duration // SANDBOXD_IDLE_THRESHOLD_SECONDS (600s)
-	Interval      time.Duration // SANDBOXD_IDLE_REAP_INTERVAL_SECONDS (30s)
-	WakeGrace     time.Duration // SANDBOXD_WAKE_GRACE_SECONDS (60s) — post-WS/SSE-disconnect grace
+	Threshold time.Duration // SANDBOXD_IDLE_THRESHOLD_SECONDS (600s)
+	Interval  time.Duration // SANDBOXD_IDLE_REAP_INTERVAL_SECONDS (30s)
+	WakeGrace time.Duration // SANDBOXD_WAKE_GRACE_SECONDS (60s) — post-WS/SSE-disconnect grace
 }
 
 // Idle is the goroutine.
 type Idle struct {
-	Cfg    IdleConfig
-	Store  *store.Store
-	Docker *docker.Client
+	Cfg      IdleConfig
+	Store    *store.Store
+	Docker   *docker.Client
 	Inflight *activity.InflightExec
-	Egress *egress.Manager // Phase 6 — nil-safe
-	Log    *slog.Logger
+	Egress   *egress.Manager // Phase 6 — nil-safe
+	Log      *slog.Logger
 }
 
 // Run blocks until ctx is cancelled. A zero or negative Interval

--- a/control-plane/internal/reaper/pressure.go
+++ b/control-plane/internal/reaper/pressure.go
@@ -16,10 +16,10 @@ import (
 // PressureConfig captures the env-tunable knobs from roadmap §12.
 // Defaults come from CLAUDE.md "Host memory pressure reaper".
 type PressureConfig struct {
-	Interval     time.Duration // SANDBOXD_PRESSURE_INTERVAL_SECONDS (10s)
-	HeadroomPct  float64       // SANDBOXD_MEM_HEADROOM_PCT          (15)
-	RefuseWakesPct float64     // SANDBOXD_MEM_REFUSE_WAKES_PCT      (10)
-	EmergencyPct float64       // SANDBOXD_MEM_EMERGENCY_PCT         (5)
+	Interval       time.Duration // SANDBOXD_PRESSURE_INTERVAL_SECONDS (10s)
+	HeadroomPct    float64       // SANDBOXD_MEM_HEADROOM_PCT          (15)
+	RefuseWakesPct float64       // SANDBOXD_MEM_REFUSE_WAKES_PCT      (10)
+	EmergencyPct   float64       // SANDBOXD_MEM_EMERGENCY_PCT         (5)
 }
 
 // Pressure is the goroutine.
@@ -29,7 +29,7 @@ type Pressure struct {
 	Docker   *docker.Client
 	Inflight *activity.InflightExec
 	Egress   *egress.Manager // Phase 6 — nil-safe
-	Refused  *atomic.Bool // shared with the wake admission code; set when in 5-10% or <5% band
+	Refused  *atomic.Bool    // shared with the wake admission code; set when in 5-10% or <5% band
 	Log      *slog.Logger
 }
 

--- a/control-plane/internal/reconcile/reconcile.go
+++ b/control-plane/internal/reconcile/reconcile.go
@@ -31,13 +31,13 @@ import (
 
 // Result is what Once returns to the caller (main.go logs + metrics).
 type Result struct {
-	Duration     time.Duration
-	Rows         int
-	Reapplied    int            // memory.high re-writes that succeeded
-	Stopped      int            // rows we marked stopped because container vanished
-	Errored      int            // rows we marked error
-	EgressAdded  int            // Phase 6 — sandbox_sources_v4 entries re-installed
-	Orphans      map[string]int // "container" / "mount" -> count
+	Duration    time.Duration
+	Rows        int
+	Reapplied   int            // memory.high re-writes that succeeded
+	Stopped     int            // rows we marked stopped because container vanished
+	Errored     int            // rows we marked error
+	EgressAdded int            // Phase 6 — sandbox_sources_v4 entries re-installed
+	Orphans     map[string]int // "container" / "mount" -> count
 }
 
 // Deps is the small set of collaborators the reconciler needs.

--- a/control-plane/internal/runtime/tasks.go
+++ b/control-plane/internal/runtime/tasks.go
@@ -63,13 +63,13 @@ type TaskResult struct {
 	// when the preview renders. Distinct from BuildErrorMessage, which
 	// is the `pnpm build` output — build_ok can be true while this is
 	// set. See cmd/runtimed/health.go.
-	PreviewErrorMessage string `json:"preview_error_message,omitempty"`
-	CheckpointID       string        `json:"checkpoint_id,omitempty"`
-	DurationMS         int64         `json:"duration_ms"`
-	Tokens             TokenUsage    `json:"tokens"`
-	CreatedAt          time.Time     `json:"created_at"`
-	StartedAt          time.Time     `json:"started_at"`
-	FinishedAt         time.Time     `json:"finished_at"`
+	PreviewErrorMessage string     `json:"preview_error_message,omitempty"`
+	CheckpointID        string     `json:"checkpoint_id,omitempty"`
+	DurationMS          int64      `json:"duration_ms"`
+	Tokens              TokenUsage `json:"tokens"`
+	CreatedAt           time.Time  `json:"created_at"`
+	StartedAt           time.Time  `json:"started_at"`
+	FinishedAt          time.Time  `json:"finished_at"`
 }
 
 // TokenUsage is the model-token accounting for one task — one

--- a/control-plane/internal/snapshot/snapshot.go
+++ b/control-plane/internal/snapshot/snapshot.go
@@ -36,9 +36,9 @@ const tsLayout = "2006-01-02-150405"
 
 // Manager owns the snapshot subsystem's configuration + collaborators.
 type Manager struct {
-	WorkspacesRoot string // /var/lib/sandboxed/workspaces
-	SnapshotsRoot  string // /var/lib/sandboxed/_snapshots
-	RetentionDays  int    // SANDBOXD_SNAPSHOT_RETENTION_DAYS (7)
+	WorkspacesRoot string        // /var/lib/sandboxed/workspaces
+	SnapshotsRoot  string        // /var/lib/sandboxed/_snapshots
+	RetentionDays  int           // SANDBOXD_SNAPSHOT_RETENTION_DAYS (7)
 	IdleThreshold  time.Duration // auto-snapshot a stopped sandbox once idle this long (24h)
 
 	Store *store.Store
@@ -48,13 +48,13 @@ type Manager struct {
 
 // Meta is the sidecar JSON written next to each snapshot.
 type Meta struct {
-	TS                 string `json:"ts"`
-	ImageTag           string `json:"image_tag,omitempty"`
-	SizeBytes          int64  `json:"size_bytes"`            // logical (apparent) size of the .img
-	CompressedSizeBytes int64 `json:"compressed_size_bytes"` // size of the .img.zst
-	HostCPUMillis      int64  `json:"host_cpu_ms"`           // zstd child user+sys CPU
-	TakenAt            string `json:"taken_at"`
-	Auto               bool   `json:"auto"` // true if the hourly snapshotter took it
+	TS                  string `json:"ts"`
+	ImageTag            string `json:"image_tag,omitempty"`
+	SizeBytes           int64  `json:"size_bytes"`            // logical (apparent) size of the .img
+	CompressedSizeBytes int64  `json:"compressed_size_bytes"` // size of the .img.zst
+	HostCPUMillis       int64  `json:"host_cpu_ms"`           // zstd child user+sys CPU
+	TakenAt             string `json:"taken_at"`
+	Auto                bool   `json:"auto"` // true if the hourly snapshotter took it
 }
 
 // Entry is one item in a List() result.
@@ -67,9 +67,9 @@ type Entry struct {
 
 // Sentinel errors for callers (the API layer maps them to HTTP codes).
 var (
-	ErrNoImg     = fmt.Errorf("snapshot: no .img on disk for this id")
-	ErrRunning   = fmt.Errorf("snapshot: sandbox row is running; DELETE it first")
-	ErrNotFound  = fmt.Errorf("snapshot: snapshot not found")
+	ErrNoImg    = fmt.Errorf("snapshot: no .img on disk for this id")
+	ErrRunning  = fmt.Errorf("snapshot: sandbox row is running; DELETE it first")
+	ErrNotFound = fmt.Errorf("snapshot: snapshot not found")
 )
 
 // imgPath / mntPath mirror loopback.Manager.Paths so snapshot doesn't

--- a/control-plane/internal/store/snapshots.go
+++ b/control-plane/internal/store/snapshots.go
@@ -10,19 +10,19 @@ import (
 // (migrations/0009). A snapshot is a reusable, frozen copy of a
 // sandbox's workspace .img — see ops/design/snapshots-as-templates.md.
 type Snapshot struct {
-	ID               string
-	Name             string
-	OwnerToken       string         // auth.Actor.Name — the tenant boundary
-	SourceSandboxID  sql.NullString // provenance
-	CreatedByUserID  sql.NullString // untrusted passthrough; provenance only
-	BaseImage        string         // recorded, not pinned
-	Visibility       string         // 'private' in v1
-	Format           string         // 'raw' in v1
-	Status           string         // ready | error
-	ImagePath        string
-	SizeBytes        sql.NullInt64
-	ErrorMessage     sql.NullString
-	CreatedAt        time.Time
+	ID              string
+	Name            string
+	OwnerToken      string         // auth.Actor.Name — the tenant boundary
+	SourceSandboxID sql.NullString // provenance
+	CreatedByUserID sql.NullString // untrusted passthrough; provenance only
+	BaseImage       string         // recorded, not pinned
+	Visibility      string         // 'private' in v1
+	Format          string         // 'raw' in v1
+	Status          string         // ready | error
+	ImagePath       string
+	SizeBytes       sql.NullInt64
+	ErrorMessage    sql.NullString
+	CreatedAt       time.Time
 }
 
 const snapshotCols = `id, name, owner_token, source_sandbox_id, created_by_user_id,

--- a/control-plane/internal/store/store.go
+++ b/control-plane/internal/store/store.go
@@ -20,18 +20,18 @@ import (
 
 // Sandbox is the in-memory mirror of a `sandbox` table row.
 type Sandbox struct {
-	ID             string
-	Status         string // creating | running | stopped | error
-	Image          string
-	WorkspaceImg   string
-	WorkspaceMnt   string
-	ContainerID    sql.NullString
-	CgroupPath     sql.NullString
-	MemoryHigh     string
-	ErrorMessage   sql.NullString
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	Ports          []int
+	ID           string
+	Status       string // creating | running | stopped | error
+	Image        string
+	WorkspaceImg string
+	WorkspaceMnt string
+	ContainerID  sql.NullString
+	CgroupPath   sql.NullString
+	MemoryHigh   string
+	ErrorMessage sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	Ports        []int
 
 	// Phase 5 — activity / lifecycle columns (migrations/0002_activity.sql).
 	LastActiveAt   time.Time     // bumped by tailer / poller / exec / wake; zero value if never observed
@@ -66,10 +66,10 @@ type WorkspaceOwner struct {
 
 // Store wraps an open *sql.DB plus the write-loop goroutine.
 type Store struct {
-	db       *sql.DB
-	writes   chan writeOp
-	doneCh   chan struct{}
-	closeCh  chan struct{}
+	db      *sql.DB
+	writes  chan writeOp
+	doneCh  chan struct{}
+	closeCh chan struct{}
 }
 
 // Open opens the database at dsn, applies migrations, and starts the

--- a/control-plane/internal/wake/admit.go
+++ b/control-plane/internal/wake/admit.go
@@ -35,10 +35,10 @@ type AdmitConfig struct {
 
 // Outcome is the result of an admission check.
 type Outcome struct {
-	Admit       bool
-	AvailPct    float64
-	AvailBytes  uint64
-	Reason      string // populated when Admit==false
+	Admit      bool
+	AvailPct   float64
+	AvailBytes uint64
+	Reason     string // populated when Admit==false
 }
 
 // Admit performs the CLAUDE.md "Wake admission" calculation:

--- a/control-plane/internal/wake/handler.go
+++ b/control-plane/internal/wake/handler.go
@@ -66,8 +66,8 @@ type Handler struct {
 
 	hostRE *regexp.Regexp
 
-	mu        sync.Mutex
-	inflight  map[string]*inflightWake
+	mu       sync.Mutex
+	inflight map[string]*inflightWake
 }
 
 // Config holds the env-tunable knobs the handler needs.
@@ -90,7 +90,7 @@ type jsonWakeResp struct {
 
 // jsonErrResp is the failure body for the JSON path.
 type jsonErrResp struct {
-	Error             string  `json:"error"`
+	Error               string  `json:"error"`
 	MemAvailablePercent float64 `json:"mem_available_percent,omitempty"`
 }
 
@@ -332,7 +332,6 @@ func (h *Handler) serve(r *http.Request, w http.ResponseWriter, id, port string,
 		}
 	}
 
-
 	rel := sb.CgroupPath.String
 	if h.SetMemoryHigh {
 		memHigh := sb.MemoryHigh
@@ -492,7 +491,7 @@ func (h *Handler) respondAdmissionDenied(w http.ResponseWriter, id string, o Out
 	}
 	w.Header().Set("Retry-After", "30")
 	writeJSON(w, http.StatusServiceUnavailable, jsonErrResp{
-		Error:              o.Reason,
+		Error:               o.Reason,
 		MemAvailablePercent: o.AvailPct,
 	})
 }


### PR DESCRIPTION
## What
- One-time `gofmt -w` on the `control-plane` Go module — **18 files** were not gofmt-clean.
- Adds the repo's **first CI** (`.github/workflows/ci.yml`): runs `gofmt -l`, `go build ./...`, and `go test ./...` on pushes to `main` and on every PR.

## Why
The module wasn't gofmt-clean anywhere and there was no automated check, so formatting drifts silently and shows up as noise in unrelated diffs. This normalizes it once and keeps it clean going forward.

## Safety
**Formatting only — no behavior change.** `go build ./...` and `go test ./...` pass identically before and after (verified locally).

## Note
Pure formatting churn, so it's cleanest to merge when other open PRs (e.g. #14) are at a quiet point, then let CI keep things clean.
