### PR TITLE
feat: opt-in gVisor (runsc) runtime for sandboxes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,16 @@ HTTP_PORT=80
 SANDBOXD_IMAGE=sandboxd-base:1.0.0
 SANDBOXD_NETWORK=sandboxd_net
 
+# ── Runtime (gVisor, opt-in) ─────────────────────────────────────────
+# Container runtime for sandboxes. Empty = Docker default (runc).
+# Set "runsc" to run every sandbox under gVisor for stronger kernel
+# isolation. Requires runsc installed + registered in daemon.json with
+# runtimeArgs ["--host-uds=create"]. See docs/gvisor.md.
+SANDBOXD_RUNTIME=
+# Resolvers for sandboxes (CSV). Only used when SANDBOXD_RUNTIME=runsc
+# (gVisor can't reach Docker's embedded DNS). Default: 1.1.1.1,8.8.8.8
+SANDBOXD_DNS=
+
 # ── Storage ──────────────────────────────────────────────────────────
 # Workspaces, SQLite state and the shared access log live here. MUST be
 # an absolute path; it is bind-mounted host:container symmetric (see

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -322,6 +322,36 @@ func main() {
 	wakeHandler.ForwardAuthDenyMode = denyMode
 	wakeHandler.SetMemoryHigh = setMemoryHigh
 
+	// gVisor (opt-in): SANDBOXD_RUNTIME=runsc runs sandboxes under runsc.
+	// gVisor's netstack can't reach Docker's embedded DNS (127.0.0.11) on a
+	// user-defined network, so we write a resolv.conf with real nameservers
+	// (SANDBOXD_DNS, default public resolvers) and bind-mount it into each
+	// sandbox. Requires runsc registered with `--host-uds=create` (docs/gvisor.md).
+	runtime := envDefault("SANDBOXD_RUNTIME", "")
+	var dnsResolvConf string
+	if runtime == "runsc" {
+		var ns []string
+		for _, d := range strings.Split(os.Getenv("SANDBOXD_DNS"), ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				ns = append(ns, d)
+			}
+		}
+		if len(ns) == 0 {
+			ns = []string{"1.1.1.1", "8.8.8.8"}
+		}
+		var b strings.Builder
+		for _, n := range ns {
+			fmt.Fprintf(&b, "nameserver %s\n", n)
+		}
+		dnsResolvConf = filepath.Join(dataDir, "gvisor-resolv.conf")
+		if err := os.WriteFile(dnsResolvConf, []byte(b.String()), 0o644); err != nil {
+			log.Error("gvisor: write resolv.conf failed; sandbox DNS may not resolve", "err", err.Error())
+			dnsResolvConf = ""
+		} else {
+			log.Info("gvisor runtime enabled", "runtime", runtime, "dns", ns)
+		}
+	}
+
 	server := &api.Server{
 		Store:               st,
 		Docker:              dockerClient,
@@ -331,6 +361,8 @@ func main() {
 		Image:               image,
 		Network:             network,
 		Userns:              userns,
+		Runtime:             runtime,
+		DNSResolvConf:       dnsResolvConf,
 		PreviewEntrypoint:   previewEntrypoint,
 		PreviewTLS:          previewTLS,
 		SetMemoryHigh:       setMemoryHigh,

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -44,6 +44,8 @@ type Server struct {
 	//                        portable build (the --memory ceiling still applies).
 	Network           string
 	Userns            string
+	Runtime           string
+	DNSResolvConf     string
 	PreviewEntrypoint string
 	PreviewTLS        bool
 	SetMemoryHigh     bool

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -535,11 +535,17 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	labels := traefik.Labels(req.ID, req.Ports, s.PreviewDomain, visibility, s.PreviewEntrypoint, s.PreviewTLS)
 	startRun := time.Now()
 	var runErr error
+	vols := []string{mntPath + ":/home/sandbox"}
+	if s.DNSResolvConf != "" {
+		// gVisor: override the unreachable embedded DNS (127.0.0.11).
+		vols = append(vols, s.DNSResolvConf+":/etc/resolv.conf:ro")
+	}
 	containerID, runErr := s.Docker.Run(r.Context(), docker.RunSpec{
 		Name:        "s-" + req.ID,
 		Hostname:    "s-" + req.ID,
 		Network:     s.Network,
 		Userns:      s.Userns,
+		Runtime:     s.Runtime,
 		ReadOnly:    true,
 		CapDrop:     []string{"ALL"},
 		SecurityOpt: []string{"no-new-privileges"},
@@ -550,7 +556,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Ulimits:     []string{"nofile=65536:65536"},
 		Tmpfs:       []string{"/tmp:size=512m", "/var/tmp:size=128m"},
 		Env:         envFlags,
-		Volumes:     []string{mntPath + ":/home/sandbox"},
+		Volumes:     vols,
 		Labels:      labels,
 		Image:       s.Image,
 	})

--- a/control-plane/internal/docker/docker.go
+++ b/control-plane/internal/docker/docker.go
@@ -39,6 +39,7 @@ type RunSpec struct {
 	Hostname    string   // --hostname
 	Network     string   // --network (OSS: shared sandboxd_net so Traefik can route)
 	Userns      string   // --userns (OSS: "host" for deterministic workspace ownership)
+	Runtime     string   // --runtime ("runsc"=gVisor); "" = daemon default (runc)
 	ReadOnly    bool     // --read-only
 	CapDrop     []string // --cap-drop=ALL (passed once per entry)
 	SecurityOpt []string // --security-opt=no-new-privileges
@@ -69,6 +70,9 @@ func (c *Client) Run(ctx context.Context, spec RunSpec) (string, error) {
 	}
 	if spec.Userns != "" {
 		args = append(args, "--userns", spec.Userns)
+	}
+	if spec.Runtime != "" {
+		args = append(args, "--runtime", spec.Runtime)
 	}
 	if spec.ReadOnly {
 		args = append(args, "--read-only")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       SANDBOXD_IMAGE: ${SANDBOXD_IMAGE:-sandboxd-base:1.0.0}
       SANDBOXD_NETWORK: ${SANDBOXD_NETWORK:-sandboxd_net}
       SANDBOXD_USERNS: ${SANDBOXD_USERNS:-host}
+      SANDBOXD_RUNTIME: ${SANDBOXD_RUNTIME:-}
+      SANDBOXD_DNS: ${SANDBOXD_DNS:-}
       SANDBOXD_DATA_DIR: ${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}
       SANDBOXD_LOG_DIR: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}
       SANDBOXD_ACCESS_LOG: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}/traefik-access.log

--- a/docs/gvisor.md
+++ b/docs/gvisor.md
@@ -1,0 +1,85 @@
+# gVisor runtime (opt-in)
+
+By default sandboxd runs each sandbox under Docker's standard runtime (`runc`),
+hardened with `cap-drop ALL`, read-only rootfs, `no-new-privileges`, and
+per-sandbox memory/PID limits. That's a shared-kernel boundary — appropriate for
+the project's threat model (authenticated users running their own code), but it
+is not a defense against kernel-CVE container escape.
+
+For stronger, per-sandbox **kernel isolation** — useful if you run less-trusted
+code — sandboxd can run every sandbox under [gVisor](https://gvisor.dev)
+(`runsc`). It is strictly opt-in; the default stays `runc`.
+
+## Setup
+
+### 1. Install runsc
+
+Follow the official [gVisor install guide](https://gvisor.dev/docs/user_guide/install/)
+(download `runsc` + `containerd-shim-runsc-v1`, verify the checksums, and place
+them on `PATH`). gVisor supports x86_64 and ARM64.
+
+### 2. Register the runtime with `--host-uds=create` (required)
+
+sandboxd talks to the in-sandbox supervisor (`runtimed`) over a Unix socket on
+the workspace bind-mount. gVisor's gofer does **not** expose a socket created
+inside the sandbox to the host unless `--host-uds=create` is set — without it,
+every task / exec / status call fails. Add to `/etc/docker/daemon.json`:
+
+```json
+{
+  "runtimes": {
+    "runsc": {
+      "path": "/usr/local/bin/runsc",
+      "runtimeArgs": ["--host-uds=create"]
+    }
+  }
+}
+```
+
+Then reload Docker (a reload, not a restart, so running containers aren't
+disturbed):
+
+```
+sudo systemctl reload docker
+docker info | grep -i runtimes   # should list: runsc
+```
+
+### 3. Enable it in sandboxd
+
+In `.env`:
+
+```
+SANDBOXD_RUNTIME=runsc
+# optional — resolvers for sandboxes (default: 1.1.1.1,8.8.8.8)
+SANDBOXD_DNS=1.1.1.1,8.8.8.8
+```
+
+Restart: `docker compose up -d`. New sandboxes now run under gVisor (`docker
+inspect s-<id> -f '{{.HostConfig.Runtime}}'` → `runsc`; `uname -r` inside →
+`*-gvisor`).
+
+## How DNS is handled
+
+On a user-defined Docker network, containers resolve names via Docker's embedded
+DNS at `127.0.0.11`, which gVisor's netstack cannot reach. When
+`SANDBOXD_RUNTIME=runsc`, sandboxd writes a `resolv.conf` (from `SANDBOXD_DNS`)
+to its data dir and bind-mounts it into each sandbox at `/etc/resolv.conf`, so
+DNS resolves. Package installs already go through the registry proxy by IP and
+are unaffected.
+
+## Trade-offs (measured on an ARM64 host with no KVM → gVisor software platform)
+
+- **Near-parity**: dev-server serving, HTTP latency (+~1 ms/req), HMR for
+  in-sandbox edits, pure CPU (~1.2×), bulk file I/O.
+- **Slower**: `pnpm install` ~1.7×; syscall/metadata-heavy work ~4× (fork/exec,
+  `stat`) — the gofer + syscall-interception cost. Container cold-start: +~0.1 s.
+- **HMR caveat**: edits made *inside* the sandbox trigger reload; host-side edits
+  to the workspace bind-mount do **not** (gVisor's gofer doesn't forward host
+  filesystem events). The agent edits files inside the sandbox, so its workflow
+  is unaffected.
+
+## Status
+
+Opt-in and experimental. The default runtime is unchanged (`runc`). Verified
+end-to-end on ARM64: create → sandbox runs under `runsc` → DNS resolves →
+preview serves.


### PR DESCRIPTION
Closes #3.

## What
Opt-in gVisor runtime: set `SANDBOXD_RUNTIME=runsc` and every sandbox runs under [gVisor](https://gvisor.dev) for stronger per-sandbox **kernel isolation**. Default is unchanged (`runc`).

## Changes
- `docker.RunSpec.Runtime` → `--runtime` on the sandbox `docker run`.
- When `runsc` is enabled, sandboxd writes a `resolv.conf` (from `SANDBOXD_DNS`, default `1.1.1.1,8.8.8.8`) and bind-mounts it into each sandbox at `/etc/resolv.conf`. gVisor's netstack can't reach Docker's embedded DNS (`127.0.0.11`) on a user-defined network, so without this the agent/DNS wouldn't resolve.
- `.env.example` + `docker-compose.yml` knobs; `docs/gvisor.md`.

## Operator requirement (documented)
`runsc` must be registered with `runtimeArgs: ["--host-uds=create"]` — sandboxd reaches `runtimed` over a Unix socket on the workspace bind-mount, and gVisor's gofer only exposes a sandbox-created socket to the host with that flag. Without it, tasks/exec/status fail. Full setup in `docs/gvisor.md`.

## Verified end-to-end (ARM64, no KVM → software platform)
```
create → runtime=runsc → uname 4.19.0-gvisor
/etc/resolv.conf = 1.1.1.1,8.8.8.8 (bind-mount)
getent github.com → 20.233.83.145 ; curl github → 200
```
Build + full test suite + gofmt CI all green.

## Trade-offs (measured)
Near-parity for serving / HTTP / in-sandbox HMR / CPU / bulk I/O; `pnpm install` ~1.7×; syscall-heavy microbenchmarks ~4×. Host-side file edits don't trigger HMR under gVisor's gofer (in-sandbox edits do). See `docs/gvisor.md`.

Opt-in and experimental; zero impact when `SANDBOXD_RUNTIME` is unset.
