### PR TITLE
  chore(image): switch Claude Code install to official native installer

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -102,8 +102,14 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
  && rm -rf /root/.bun
 
 # Claude Code + OpenCode (npm globals).
-RUN npm install -g @anthropic-ai/claude-code opencode-ai \
- && npm cache clean --force
+#RUN npm install -g @anthropic-ai/claude-code opencode-ai \
+# && npm cache clean --force
+
+
+# Install Claude Code (official native method)
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    cp /root/.local/bin/claude /usr/local/bin/claude && \
+    chmod 755 /usr/local/bin/claude
 
 # Registry-proxy config + shell env file. /etc/npmrc and /usr/etc/npmrc
 # both ship the same content; /usr/etc/npmrc is the path Node 20's npm

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -101,15 +101,11 @@ RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
  && mv /root/.bun/bin/bun /usr/local/bin/bun \
  && rm -rf /root/.bun
 
-# Claude Code + OpenCode (npm globals).
-#RUN npm install -g @anthropic-ai/claude-code opencode-ai \
-# && npm cache clean --force
-
-
-# Install Claude Code (official native method)
-RUN curl -fsSL https://claude.ai/install.sh | bash && \
-    cp /root/.local/bin/claude /usr/local/bin/claude && \
-    chmod 755 /usr/local/bin/claude
+# OpenCode (npm global) + Claude Code (official native installer).
+RUN npm install -g opencode-ai \
+ && curl -fsSL https://claude.ai/install.sh | bash \
+ && cp /root/.local/bin/claude /usr/local/bin/claude \
+ && chmod 755 /usr/local/bin/claude
 
 # Registry-proxy config + shell env file. /etc/npmrc and /usr/etc/npmrc
 # both ship the same content; /usr/etc/npmrc is the path Node 20's npm


### PR DESCRIPTION
 ## Summary
  Switch the base image's Claude Code install from the npm package
  (`@anthropic-ai/claude-code`) to Anthropic's official
  `claude.ai/install.sh`, and copy the resulting binary into
  `/usr/local/bin/claude` so it is on PATH for the runtime container.

  ## Why
  The current Dockerfile line:
  ```dockerfile
  RUN npm install -g @anthropic-ai/claude-code opencode-ai \
   && npm cache clean --force
  produced a broken install in practice:

  - The claude binary from the npm package is not on PATH in the
  runtime container, so claude commands fail with "executable file
  not found" (the user-visible symptom: any attempt to run a coding
  task via runtimed errors out at the start).
  - The opencode-ai install leaves a second tool the README claims is
  pre-installed, but the runtime task API only ships a claude
  adapter; with opencode absent the image ends up with neither
  tool working as documented.

  Replacing the npm install with the official claude.ai/install.sh
  fixes both: claude lands on PATH, and the comment about a
  non-existent second tool is removed.

  Test

  Rebuilt the base image locally; inside the runtime container:
  $ which claude
  /usr/local/bin/claude
  $ claude --version
  2.1.177 (Claude Code)

  Follow-ups (intentionally out of scope for this PR)

  - Pin claude.ai/install.sh to a specific version and verify its
  checksum (today the Dockerfile fetches it with curl -fsSL | bash
  and no integrity check).
  - Either reinstall opencode-ai so the README's claim of
  "OpenCode and Claude Code pre-installed" is true again, or update
  the README to state that only claude is pre-installed.

  Diff

  image/Dockerfile: +8 / -2