### PR TITLE
fix: 4 confirmed items from audit #19/#20 (+ tests)

### DIFF
--- a/control-plane/cmd/runtimed/health.go
+++ b/control-plane/cmd/runtimed/health.go
@@ -93,7 +93,7 @@ func (a *app) runPostTaskChecks(ctx context.Context, filesChanged []string) stri
 			attrs = append(attrs, "remediated", true)
 		}
 		if f.previewError != "" {
-			attrs = append(attrs, "preview_error", true)
+			attrs = append(attrs, "preview_error", f.previewError)
 			if previewErr == "" {
 				previewErr = f.previewError
 			}

--- a/control-plane/internal/activity/inflight_exec.go
+++ b/control-plane/internal/activity/inflight_exec.go
@@ -47,14 +47,18 @@ func (i *InflightExec) Enter(id string) {
 // reaching zero deletes the map entry to keep the map small.
 func (i *InflightExec) Exit(id string) {
 	i.mu.Lock()
+	decremented := false
 	if i.n[id] > 0 {
 		i.n[id]--
 		if i.n[id] == 0 {
 			delete(i.n, id)
 		}
+		decremented = true
 	}
 	i.mu.Unlock()
-	metrics.InflightExec.Dec()
+	if decremented {
+		metrics.InflightExec.Dec()
+	}
 }
 
 // Active returns true if the sandbox has any in-flight exec call.

--- a/control-plane/internal/activity/inflight_exec_test.go
+++ b/control-plane/internal/activity/inflight_exec_test.go
@@ -1,0 +1,36 @@
+package activity
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/sandboxd/control-plane/internal/metrics"
+)
+
+func inflightGauge(t *testing.T) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := metrics.InflightExec.Write(&m); err != nil {
+		t.Fatalf("read gauge: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}
+
+// An unbalanced Exit (no matching Enter) must not drive the exported gauge
+// negative — Dec() fires only when the map counter actually decrements.
+func TestInflightExecGaugeStaysBalanced(t *testing.T) {
+	ie := NewInflightExec()
+	base := inflightGauge(t)
+	ie.Enter("a")
+	if d := inflightGauge(t) - base; d != 1 {
+		t.Fatalf("after Enter: gauge delta=%v, want 1", d)
+	}
+	ie.Exit("a")
+	if d := inflightGauge(t) - base; d != 0 {
+		t.Fatalf("after balanced Exit: gauge delta=%v, want 0", d)
+	}
+	ie.Exit("a") // unbalanced
+	if d := inflightGauge(t) - base; d != 0 {
+		t.Fatalf("after unbalanced Exit: gauge delta=%v, want 0 (regression: went negative)", d)
+	}
+}

--- a/control-plane/internal/api/external_purge.go
+++ b/control-plane/internal/api/external_purge.go
@@ -107,6 +107,10 @@ func diskBytes(path string) int64 {
 
 func (s *Server) handlePurgeSandbox(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if !isULID(id) {
+		writeErr(w, http.StatusBadRequest, "invalid sandbox id")
+		return
+	}
 	freed, externalUserID, err := s.purgeOne(r.Context(), id)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "purge: "+err.Error())

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -288,7 +289,7 @@ func isULID(s string) bool {
 
 func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	var req createReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		writeErr(w, http.StatusBadRequest, "invalid json: "+err.Error())
 		return
 	}

--- a/control-plane/internal/api/id_validation_test.go
+++ b/control-plane/internal/api/id_validation_test.go
@@ -1,0 +1,15 @@
+package api
+
+import "testing"
+
+// isULID guards destructive/path-deriving handlers (purge, file write).
+func TestIsULIDRejectsUnsafeIDs(t *testing.T) {
+	for _, id := range []string{"", "..", "../etc", "a/b", `a\b`, "/abs", "short", "0"} {
+		if isULID(id) {
+			t.Errorf("isULID(%q) = true, want false", id)
+		}
+	}
+	if !isULID("01ARZ3NDEKTSV4RRFFQ69G5FAV") {
+		t.Error("isULID rejected a valid 26-char ULID")
+	}
+}

--- a/control-plane/internal/api/v1_files_write.go
+++ b/control-plane/internal/api/v1_files_write.go
@@ -120,6 +120,10 @@ func mountOwner(mnt string) (uid, gid int) {
 // v1PutFile is the handler for PUT /v1/sandboxes/{id}/files.
 func (s *Server) v1PutFile(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	if !isULID(id) {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid sandbox id")
+		return
+	}
 	_, mnt := s.Loopback.Paths(id)
 	if info, err := os.Stat(mnt); err != nil || !info.IsDir() {
 		writeV1Err(w, http.StatusNotFound, "not_found", "no workspace for that sandbox")


### PR DESCRIPTION
Triaged the two automated code-audit issues (#19 and #20 — overlapping runs of the same tool) against the actual code and sandboxd's threat model. Of the ~62 findings, **4 are actionable** — fixed here with tests. The rest are false positives, expected sandbox behavior, or operator-trusted config (rationale posted on #19/#20).

## Fixes
| Fix | File(s) |
|---|---|
| **Inflight gauge can't go negative** — `Dec()` only when the map counter decrements (an unbalanced `Exit` was decrementing the exported gauge). **+ regression test** | `internal/activity/inflight_exec.go` |
| **Validate sandbox id before filesystem ops** — `isULID(id)` → `400` before the destructive `os.RemoveAll` (purge) and the workspace file-write. **+ test** | `internal/api/external_purge.go`, `internal/api/v1_files_write.go` |
| **`errors.Is(err, io.EOF)`** instead of brittle `err.Error() != "EOF"` | `internal/api/handlers.go` |
| **Log the real preview error** message instead of `true` | `cmd/runtimed/health.go` |

### Note on the id validation
This is **defense-in-depth, not a live vuln**: Go 1.22's `ServeMux` cleans `..` segments and `{id}` matches a single path segment, so a traversal id can't be routed to these handlers via HTTP today. But both `handlePurgeSandbox` (→ `os.RemoveAll`) and `v1PutFile` (→ workspace write) derive a filesystem path from the raw path-param id with no validation, so guarding them with the same `isULID` check `handleCreate` already uses is cheap, correct hardening.

CI: build + full test suite + gofmt green. 2 new unit tests.
