### PR TITLE
feat(api): forward timeout_s in v1 task submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ by default** for local use; with `SANDBOXD_API_AUTH_DISABLED=false` +
 | `POST /v1/sandboxes/{id}/stop` | — | stop now to free RAM (wakes on next preview hit) |
 | `DELETE /sandbox/{id}` | — | destroy the container, **keep** the workspace |
 | `POST /sandbox/{id}/purge` | — | destroy **and delete** the workspace |
-| `POST /v1/sandboxes/{id}/tasks` | `{"prompt":"…","agent":"opencode"}` | run a coding agent headlessly |
+| `POST /v1/sandboxes/{id}/tasks` | `{"prompt":"…","agent":"opencode","timeout_s":600}` | run a coding agent headlessly (`timeout_s` optional: 0/omitted → 10m default, max 24h) |
 | `GET /v1/sandboxes/{id}/tasks/{taskId}` | — | task result |
 | `GET /v1/sandboxes/{id}/tasks/{taskId}/events` | — | live task event stream (SSE) |
 | `GET/PUT /v1/sandboxes/{id}/files` | `{"path","content","append"}` | list / read / write workspace files |

--- a/control-plane/cmd/runtimed/task.go
+++ b/control-plane/cmd/runtimed/task.go
@@ -20,7 +20,7 @@ import (
 
 var errTaskInProgress = errors.New("a task is already in progress")
 
-const defaultTaskTimeout = 10 * time.Minute
+const defaultTaskTimeout = runtime.DefaultTaskTimeout
 
 // eventSink receives canonical events from an agent adapter.
 type eventSink func(evType string, data any)

--- a/control-plane/internal/api/taskwatch.go
+++ b/control-plane/internal/api/taskwatch.go
@@ -12,9 +12,25 @@ import (
 )
 
 const (
-	taskWatchTimeout  = 15 * time.Minute // outlives the runtimed task timeout
+	// watchMargin is the slack the watcher keeps beyond the task's own
+	// timeout, so it is still streaming when runtimed emits the terminal
+	// `done` event — which, on a timeout, fires right at the deadline.
+	watchMargin       = 5 * time.Minute
 	taskWatchAttempts = 3
 )
+
+// watchWindowFor is how long watchTask streams events before giving up.
+// It MUST outlive the runtimed task timeout (the 10m default, or the
+// caller's timeout_s): a shorter window aborts the stream and marks a
+// still-running task failed. Earlier this was a fixed 15m, which
+// quietly capped any task whose timeout_s exceeded ~15m.
+func watchWindowFor(timeoutS int) time.Duration {
+	eff := runtime.DefaultTaskTimeout
+	if timeoutS > 0 {
+		eff = time.Duration(timeoutS) * time.Second
+	}
+	return eff + watchMargin
+}
 
 // failedResult builds a clean terminal result for a task that could
 // not complete normally. failure_reason is always an existing model
@@ -35,9 +51,17 @@ func failedResult(taskID, reason, msg string) *runtime.TaskResult {
 // to SQLite when the terminal `done` event arrives — independent of
 // whether any client ever connects to the public events stream. This
 // is what makes a task's result durable past the sandbox's lifetime.
-func (s *Server) watchTask(sandboxID, taskID string) {
+// watchTask streams a task's events under a window derived from its
+// timeout (taskTimeoutS; 0 = the runtimed default). See watchWindowFor.
+func (s *Server) watchTask(sandboxID, taskID string, taskTimeoutS int) {
+	s.watchTaskWindow(sandboxID, taskID, watchWindowFor(taskTimeoutS))
+}
+
+// watchTaskWindow is watchTask with an explicit streaming window. Split
+// out so tests can inject a short window instead of waiting minutes.
+func (s *Server) watchTaskWindow(sandboxID, taskID string, window time.Duration) {
 	log := s.Log.With("component", "taskwatch", "task", taskID)
-	ctx, cancel := context.WithTimeout(context.Background(), taskWatchTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), window)
 	defer cancel()
 
 	rc := s.runtimeClientFor(sandboxID)
@@ -127,7 +151,7 @@ func (s *Server) ReconcileTasks(ctx context.Context) {
 		}
 		if sb, gerr := s.Store.Get(ctx, t.SandboxID); gerr == nil && sb.Status == "running" {
 			s.Log.Info("task reconcile: sandbox running — re-attaching watcher", "task", t.TaskID)
-			go s.watchTask(t.SandboxID, t.TaskID)
+			go s.watchTask(t.SandboxID, t.TaskID, t.TimeoutS)
 			continue
 		}
 		s.finishWatchedTask(t.TaskID, failedResult(t.TaskID, "sandbox_unavailable",

--- a/control-plane/internal/api/taskwatch_test.go
+++ b/control-plane/internal/api/taskwatch_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sandboxd/control-plane/internal/loopback"
+	"github.com/sandboxd/control-plane/internal/runtime"
+	"github.com/sandboxd/control-plane/internal/store"
+)
+
+// --- the policy: the watch window must outlive the task's timeout -----
+//
+// The watcher streams runtimed's events under a context deadline. If
+// that deadline is shorter than the task's own timeout, the watcher
+// aborts the stream and marks a still-running task failed. So the
+// window must ALWAYS exceed the effective runtimed task timeout — the
+// 10m default, or timeout_s when the caller sets one (up to 24h).
+func TestWatchWindowOutlivesTaskTimeout(t *testing.T) {
+	cases := []struct {
+		name     string
+		timeoutS int
+		floor    time.Duration // window must exceed this
+	}{
+		{"default (0 → 10m)", 0, runtime.DefaultTaskTimeout},
+		{"one hour", 3600, time.Hour},
+		{"max 24h", 86400, 24 * time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := watchWindowFor(c.timeoutS)
+			if got <= c.floor {
+				t.Errorf("watchWindowFor(%d) = %v; must exceed the task timeout %v",
+					c.timeoutS, got, c.floor)
+			}
+		})
+	}
+}
+
+// --- the mechanism: a fast fake runtimed over a unix socket ----------
+//
+// No clock mocking: the test injects a small watch window (hundreds of
+// ms) instead of minutes, so the timeout vs. terminal-event race plays
+// out in real time, instantly.
+
+type fakeEvent struct {
+	delay time.Duration
+	ev    runtime.Event
+}
+
+const (
+	testSandboxID = "sbx-test"
+	testTaskID    = "task-test"
+)
+
+// fakeRuntimed stands up a unix-socket HTTP server at the path
+// runtimeClientFor expects (<mnt>/.runtimed/sock) and a Server wired to
+// a fresh in-memory store with one running task row. Returns the Server
+// plus the sandbox/task ids.
+func fakeRuntimed(t *testing.T, events []fakeEvent) (*Server, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	sandboxID, taskID := testSandboxID, testTaskID
+
+	sockDir := filepath.Join(root, sandboxID, ".runtimed")
+	if err := os.MkdirAll(sockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", filepath.Join(sockDir, "sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /tasks/{id}/events", func(w http.ResponseWriter, r *http.Request) {
+		fl, _ := w.(http.Flusher)
+		enc := json.NewEncoder(w)
+		for _, e := range events {
+			if e.delay > 0 {
+				select {
+				case <-time.After(e.delay):
+				case <-r.Context().Done():
+					return
+				}
+			}
+			if enc.Encode(e.ev) != nil {
+				return
+			}
+			if fl != nil {
+				fl.Flush()
+			}
+		}
+		<-r.Context().Done() // hold open like a live task until the client gives up
+	})
+	srv := &http.Server{Handler: mux}
+	go srv.Serve(ln)
+	t.Cleanup(func() { srv.Close() })
+
+	st, err := store.Open(context.Background(), "file::memory:?_fk=1", "../../migrations")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	if err := st.CreateTask(context.Background(), &store.Task{
+		TaskID: taskID, SandboxID: sandboxID, Agent: "opencode", Prompt: "x",
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	s := &Server{
+		Store:    st,
+		Loopback: &loopback.Manager{Root: root},
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	return s, sandboxID, taskID
+}
+
+func statusEvent() runtime.Event {
+	return runtime.Event{ID: 1, Type: runtime.EventStatus, Time: time.Now().UTC(),
+		Data: json.RawMessage(`{"phase":"working"}`)}
+}
+
+func doneEvent(taskID string, status runtime.TaskStatus) runtime.Event {
+	tr := runtime.TaskResult{ID: taskID, Status: status, FilesChanged: []string{}}
+	data, _ := json.Marshal(tr)
+	return runtime.Event{ID: 2, Type: runtime.EventDone, Time: time.Now().UTC(), Data: data}
+}
+
+// A task that finishes inside its window has its terminal result
+// persisted — the case the 15m cap silently broke for long tasks.
+func TestWatchTaskPersistsResultWithinWindow(t *testing.T) {
+	s, sandboxID, taskID := fakeRuntimed(t, []fakeEvent{
+		{0, statusEvent()},
+		{30 * time.Millisecond, doneEvent(testTaskID, runtime.TaskSucceeded)},
+	})
+	s.watchTaskWindow(sandboxID, taskID, 2*time.Second)
+
+	got, err := s.Store.GetTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != string(runtime.TaskSucceeded) {
+		t.Errorf("task status = %q; want %q", got.Status, runtime.TaskSucceeded)
+	}
+}
+
+// When the stream stays silent past the window the watcher gives up and
+// records a clean internal failure — this is exactly the abort path the
+// 15m cap took for any task running longer than 15m.
+func TestWatchTaskFailsWhenSilentPastWindow(t *testing.T) {
+	s, sandboxID, taskID := fakeRuntimed(t, []fakeEvent{
+		{0, statusEvent()}, // ...then the handler holds the stream open, no `done`
+	})
+	start := time.Now()
+	s.watchTaskWindow(sandboxID, taskID, 150*time.Millisecond)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("watcher did not honor the %v window (took %v)", 150*time.Millisecond, elapsed)
+	}
+	got, err := s.Store.GetTask(context.Background(), taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != string(runtime.TaskFailed) {
+		t.Errorf("task status = %q; want %q", got.Status, runtime.TaskFailed)
+	}
+}

--- a/control-plane/internal/api/v1_tasks.go
+++ b/control-plane/internal/api/v1_tasks.go
@@ -22,8 +22,11 @@ func (s *Server) runtimeClientFor(id string) *runtime.Client {
 // --- POST /v1/sandboxes/{id}/tasks ----------------------------------
 
 type v1TaskSubmitReq struct {
-	Prompt string `json:"prompt"`
-	Agent  string `json:"agent,omitempty"`
+	Prompt   string `json:"prompt"`
+	Agent    string `json:"agent,omitempty"`
+	// TimeoutS sets the maximum task runtime in seconds.
+	// 0 or omitted means use the runtimed default (10m).
+	TimeoutS int `json:"timeout_s,omitempty"`
 }
 
 func (s *Server) v1SubmitTask(w http.ResponseWriter, r *http.Request) {
@@ -78,10 +81,21 @@ func (s *Server) v1SubmitTask(w http.ResponseWriter, r *http.Request) {
 			"only the 'opencode' agent is supported")
 		return
 	}
+	if req.TimeoutS < 0 {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request",
+			"timeout_s must be >= 0")
+		return
+	}
+	const maxTimeoutS = 86400 // 24h
+	if req.TimeoutS > maxTimeoutS {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("timeout_s must be <= %d", maxTimeoutS))
+		return
+	}
 
 	taskID := newULID()
 	if err := s.runtimeClientFor(id).StartTask(r.Context(), runtime.StartTaskRequest{
-		TaskID: taskID, Prompt: req.Prompt, Agent: agent,
+		TaskID: taskID, Prompt: req.Prompt, Agent: agent, TimeoutS: req.TimeoutS,
 	}); err != nil {
 		if errors.Is(err, runtime.ErrTaskInProgress) {
 			writeV1Err(w, http.StatusConflict, "task_in_progress", "a task is already in progress")

--- a/control-plane/internal/api/v1_tasks.go
+++ b/control-plane/internal/api/v1_tasks.go
@@ -22,8 +22,8 @@ func (s *Server) runtimeClientFor(id string) *runtime.Client {
 // --- POST /v1/sandboxes/{id}/tasks ----------------------------------
 
 type v1TaskSubmitReq struct {
-	Prompt   string `json:"prompt"`
-	Agent    string `json:"agent,omitempty"`
+	Prompt string `json:"prompt"`
+	Agent  string `json:"agent,omitempty"`
 	// TimeoutS sets the maximum task runtime in seconds.
 	// 0 or omitted means use the runtimed default (10m).
 	TimeoutS int `json:"timeout_s,omitempty"`
@@ -109,13 +109,14 @@ func (s *Server) v1SubmitTask(w http.ResponseWriter, r *http.Request) {
 	if err := s.Store.CreateTask(r.Context(), &store.Task{
 		TaskID: taskID, SandboxID: id, Agent: agent, Prompt: req.Prompt,
 		Status:         "running",
+		TimeoutS:       req.TimeoutS,
 		ExternalUserID: sb.ExternalUserID, ExternalProjectID: sb.ExternalProjectID,
 	}); err != nil {
 		// The task is running in runtimed but the row failed to write.
 		// The task still proceeds; GET would 404 until reconciled.
 		s.loggerFor(r, id).Error("v1 task: CreateTask failed", "task", taskID, "err", err.Error())
 	} else {
-		go s.watchTask(id, taskID)
+		go s.watchTask(id, taskID, req.TimeoutS)
 	}
 
 	s.auditAction(r, audit.Entry{

--- a/control-plane/internal/runtime/tasks.go
+++ b/control-plane/internal/runtime/tasks.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+// DefaultTaskTimeout is the runtimed task timeout applied when a task
+// submits no explicit timeout_s. It is the single source of truth for
+// the default, shared by runtimed (which enforces it) and the
+// control-plane task watcher (which must outlive it).
+const DefaultTaskTimeout = 10 * time.Minute
+
 // TaskStatus is the lifecycle state of a coding task.
 type TaskStatus string
 

--- a/control-plane/internal/store/tasks.go
+++ b/control-plane/internal/store/tasks.go
@@ -19,6 +19,7 @@ type Task struct {
 	Prompt            string
 	Status            string // running | succeeded | failed | cancelled
 	ResultJSON        sql.NullString
+	TimeoutS          int // task timeout in seconds; 0 = runtimed default
 	CreatedAt         time.Time
 	FinishedAt        sql.NullInt64
 }
@@ -29,10 +30,10 @@ func (s *Store) CreateTask(ctx context.Context, t *Task) error {
 		_, err := db.ExecContext(ctx, `
 			INSERT INTO task
 			  (task_id, sandbox_id, external_user_id, external_project_id,
-			   agent, prompt, status, created_at)
-			VALUES (?,?,?,?,?,?,'running',?)`,
+			   agent, prompt, status, timeout_s, created_at)
+			VALUES (?,?,?,?,?,?,'running',?,?)`,
 			t.TaskID, t.SandboxID, t.ExternalUserID, t.ExternalProjectID,
-			t.Agent, t.Prompt, time.Now().Unix())
+			t.Agent, t.Prompt, t.TimeoutS, time.Now().Unix())
 		return err
 	})
 }
@@ -54,10 +55,10 @@ func (s *Store) GetTask(ctx context.Context, taskID string) (*Task, error) {
 	var created int64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT task_id, sandbox_id, external_user_id, external_project_id,
-		       agent, prompt, status, result_json, created_at, finished_at
+		       agent, prompt, status, result_json, timeout_s, created_at, finished_at
 		  FROM task WHERE task_id=?`, taskID).Scan(
 		&t.TaskID, &t.SandboxID, &t.ExternalUserID, &t.ExternalProjectID,
-		&t.Agent, &t.Prompt, &t.Status, &t.ResultJSON, &created, &t.FinishedAt)
+		&t.Agent, &t.Prompt, &t.Status, &t.ResultJSON, &t.TimeoutS, &created, &t.FinishedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -73,7 +74,7 @@ func (s *Store) GetTask(ctx context.Context, taskID string) (*Task, error) {
 func (s *Store) ListRunningTasks(ctx context.Context) ([]*Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT task_id, sandbox_id, external_user_id, external_project_id,
-		       agent, prompt, status, result_json, created_at, finished_at
+		       agent, prompt, status, result_json, timeout_s, created_at, finished_at
 		  FROM task WHERE status='running'`)
 	if err != nil {
 		return nil, err
@@ -85,7 +86,7 @@ func (s *Store) ListRunningTasks(ctx context.Context) ([]*Task, error) {
 		var created int64
 		if err := rows.Scan(&t.TaskID, &t.SandboxID, &t.ExternalUserID,
 			&t.ExternalProjectID, &t.Agent, &t.Prompt, &t.Status,
-			&t.ResultJSON, &created, &t.FinishedAt); err != nil {
+			&t.ResultJSON, &t.TimeoutS, &created, &t.FinishedAt); err != nil {
 			return nil, err
 		}
 		t.CreatedAt = time.Unix(created, 0).UTC()

--- a/control-plane/internal/store/tasks_test.go
+++ b/control-plane/internal/store/tasks_test.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// TestTaskTimeoutRoundTrip guards the timeout_s column wiring (migration
+// 0012 + the CreateTask insert and the GetTask / ListRunningTasks
+// scans): a persisted timeout must survive a read back, so the boot-time
+// reconciler can re-attach a watcher with the right streaming window.
+func TestTaskTimeoutRoundTrip(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	if err := st.CreateTask(ctx, &Task{
+		TaskID: "01TASKTIMEOUT0000000000001", SandboxID: "01SBX00000000000000000001",
+		Agent: "opencode", Prompt: "p", TimeoutS: 3600,
+	}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	got, err := st.GetTask(ctx, "01TASKTIMEOUT0000000000001")
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.TimeoutS != 3600 {
+		t.Errorf("GetTask timeout_s = %d; want 3600", got.TimeoutS)
+	}
+
+	running, err := st.ListRunningTasks(ctx)
+	if err != nil {
+		t.Fatalf("list running: %v", err)
+	}
+	if len(running) != 1 || running[0].TimeoutS != 3600 {
+		t.Errorf("ListRunningTasks timeout_s = %+v; want one row with 3600", running)
+	}
+
+	// Default stays 0 when unset (omitted timeout_s → runtimed default).
+	if err := st.CreateTask(ctx, &Task{
+		TaskID: "01TASKNOTIMEOUT00000000001", SandboxID: "01SBX00000000000000000001",
+		Agent: "opencode", Prompt: "p",
+	}); err != nil {
+		t.Fatalf("create task 2: %v", err)
+	}
+	got2, _ := st.GetTask(ctx, "01TASKNOTIMEOUT00000000001")
+	if got2.TimeoutS != 0 {
+		t.Errorf("default timeout_s = %d; want 0", got2.TimeoutS)
+	}
+}

--- a/control-plane/migrations/0012_task_timeout.sql
+++ b/control-plane/migrations/0012_task_timeout.sql
@@ -1,0 +1,5 @@
+-- Persist a task's timeout_s so the boot-time reconciler can re-attach
+-- a watcher with a streaming window that outlives the task (a long
+-- timeout_s would otherwise revert to the default after a restart).
+-- 0 = the runtimed default (10m).
+ALTER TABLE task ADD COLUMN timeout_s INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Thanks for creating sandboxd, actually came at the perfect time to use for my own personal agents.

## Problem

The runtimed layer already accepts `timeout_s` in `StartTaskRequest`, but the public v1 API (`POST /v1/sandboxes/{id}/tasks`) does not expose it. This means the 10m `defaultTaskTimeout` in `cmd/runtimed/task.go` is always used, and callers have no way to specify a custom task timeout.

For longer-running agent tasks (e.g. 1-2 hour implementation runs), this causes premature `agent_timeout` failures.

## Fix

Forward the optional `timeout_s` field from the v1 API request through to the runtimed `StartTaskRequest`:

```go
type v1TaskSubmitReq struct {
    Prompt   string `json:"prompt"`
    Agent    string `json:"agent,omitempty"`
    TimeoutS int    `json:"timeout_s,omitempty"`  // new
}
```

And pass it through:

```go
runtime.StartTaskRequest{
    TaskID: taskID, Prompt: req.Prompt, Agent: agent, TimeoutS: req.TimeoutS,
}
```

Backwards-compatible - `omitempty` means existing clients that don't send `timeout_s` see no change in behavior.

## Side Note

This PR was created with AI and was tested in my local version.

If you want to do it another way, happy to do so.