### PR TITLE
fix(v1): make POST /v1/sandboxes work without a pre-seeded template

### DIFF
--- a/control-plane/internal/api/v1.go
+++ b/control-plane/internal/api/v1.go
@@ -206,12 +206,12 @@ func (s *Server) v1CreateSandbox(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		createBody["template_path"] = snap.ImagePath
-	} else {
-		tmpl := req.Template
-		if tmpl == "" {
-			tmpl = defaultTemplate
-		}
-		createBody["template"] = tmpl
+	} else if req.Template != "" {
+		// An explicit template clones that golden workspace. With no
+		// template the sandbox is provisioned empty (handleCreate seeds
+		// the /opt/sandbox-skel home), so the public create path works
+		// out of the box without a pre-seeded template image on the host.
+		createBody["template"] = req.Template
 	}
 	internal, _ := json.Marshal(createBody)
 	code, body := s.delegate(r, s.handleCreate, http.MethodPost, "/sandbox", nil, internal)


### PR DESCRIPTION
## Problem

The public create surface is **broken on every clean install**. `POST /v1/sandboxes` forced `template="react-standard"` whenever the caller didn't specify one (`v1.go`), and `handleCreate` then required `<TemplatesDir>/react-standard.img` to exist. Nothing in the repo, image, or `install.sh` ever seeds that file, so a default create returns:

```
400 unknown or unavailable template: react-standard
```

(Reproduced live on a clean instance before the fix.) Note this is the **programmatic `/v1`** surface — the README quickstart uses the internal `POST /sandbox`, which already works; this fixes the API an integrator hits.

## Fix

Drop the forced default. With no `template` (and no `from_snapshot`), the sandbox is provisioned **empty** — which `handleCreate` seeds from the image's `/opt/sandbox-skel` home, exactly like the internal `POST /sandbox` path. An explicitly named template is still resolved and still `400`s when unavailable, so a bad explicit template isn't silently ignored. 3-line change, no schema/API change.

## Verified live (clean instance)
- no-template `POST /v1/sandboxes` → **201**, sandbox `running`, workspace seeded ✅ (was 400)
- explicit unknown template → **400** ✅ (still rejected)

`go build` / `go vet` / `gofmt` / `go test ./...` all clean. The full create→serve loop will be guarded by the e2e CI job in the next phase.

## Note / follow-up
A no-template sandbox boots with an *empty* `workspace/app/` (the skel has no app scaffold), so the agent must scaffold from scratch — which is the root of the "agent goes off-template / `build_ok:false`" reliability problem. The real reliability fix is shipping a working **starter template** as the default; tracked separately.