### PR TITLE
ci: add e2e + image-smoke job (create → preview → wake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,36 @@ jobs:
             exit 1
           fi
 
+      - name: vet
+        run: go vet ./...
+
       - name: build
         run: go build ./...
 
       - name: test
         run: go test ./...
+
+  # End-to-end: build the base image + sandboxd and drive the real
+  # create -> seed -> install -> serve -> wake lifecycle on Docker. Also
+  # smoke-tests the image (agent CLIs + default template on PATH), so a
+  # change that drops OpenCode or the react-standard template fails here.
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: control-plane/go.mod
+
+      - name: build sandboxd
+        run: cd control-plane && go build -o /tmp/sandboxd ./cmd/sandboxd
+
+      - name: build base image
+        run: docker build -f image/Dockerfile -t sandboxed-base:ci .
+
+      - name: e2e
+        env:
+          SANDBOXD_IMAGE: sandboxed-base:ci
+          SANDBOXD_BIN: /tmp/sandboxd
+        run: bash scripts/e2e.sh

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for sandboxd against a real Docker daemon.
+# Exercises the create -> seed -> install -> serve -> wake lifecycle with
+# NO model credentials required, so it is deterministic in CI.
+#
+# Inputs (env):
+#   SANDBOXD_IMAGE  built base image tag (e.g. sandboxed-base:ci)
+#   SANDBOXD_BIN    path to a built sandboxd binary
+#
+# Run locally:  SANDBOXD_IMAGE=sandboxed-base:starter SANDBOXD_BIN=/tmp/sandboxd sudo -E bash scripts/e2e.sh
+set -uo pipefail
+
+IMG="${SANDBOXD_IMAGE:?set SANDBOXD_IMAGE}"
+BIN="${SANDBOXD_BIN:?set SANDBOXD_BIN}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+DD="$(mktemp -d)"
+NET="sbxe2e-$$"
+API="http://127.0.0.1:9191"
+SBX_PID=""
+declare -a IDS=()
+
+log() { echo "── $*"; }
+fail() { echo "❌ FAIL: $*"; exit 1; }
+
+cleanup() {
+  for id in "${IDS[@]:-}"; do
+    [ -n "$id" ] && curl -s -m30 -o /dev/null -XPOST "$API/sandbox/$id/purge" >/dev/null 2>&1 || true
+  done
+  [ -n "$SBX_PID" ] && kill "$SBX_PID" >/dev/null 2>&1 || true
+  docker network rm "$NET" >/dev/null 2>&1 || true
+  rm -rf "$DD" || true
+}
+trap cleanup EXIT
+
+mk() { curl -s -m120 -XPOST "$API/sandbox" -H 'content-type: application/json' -d "$1" | grep -oE '"id":"[^"]+"' | head -1 | cut -d'"' -f4; }
+ipof() { docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "s-$1" 2>/dev/null; }
+status() { curl -s -m5 "$API/v1/sandboxes/$1" | grep -oE '"status":"[a-z]+"' | head -1 | cut -d'"' -f4; }
+
+# 1. Image smoke: agent CLIs, toolchain, and the default template present.
+log "image smoke: required binaries + react-standard template"
+docker run --rm "$IMG" bash -lc '
+  set -e
+  for b in runtimed opencode claude node pnpm git rg; do
+    command -v "$b" >/dev/null || { echo "MISSING $b on PATH"; exit 1; }
+  done
+  test -f /opt/templates/react-standard/package.json
+' || fail "image smoke (missing binary or template)"
+
+# Start sandboxd. Idle reaper pushed out so it cannot interfere mid-test.
+mkdir -p "$DD/log" "$DD/library"
+docker network create "$NET" >/dev/null
+SANDBOXD_ADDR=127.0.0.1:9191 SANDBOXD_IMAGE="$IMG" SANDBOXD_DATA_DIR="$DD" \
+  SANDBOXD_LOG_DIR="$DD/log" SANDBOXD_NETWORK="$NET" SANDBOXD_USERNS=host \
+  SANDBOXD_LIBRARY_DIR="$DD/library" SANDBOXD_MIGRATIONS="$HERE/control-plane/migrations" \
+  SANDBOXD_DB="$DD/sandboxd.db" SANDBOXD_IDLE_THRESHOLD_SECONDS=3600 \
+  "$BIN" >"$DD/sandboxd.log" 2>&1 &
+SBX_PID=$!
+for i in $(seq 1 60); do curl -s -m2 "$API/healthz" 2>/dev/null | grep -q ok && break; sleep 0.5; done
+curl -s -m3 "$API/healthz" | grep -q ok || { cat "$DD/sandboxd.log"; fail "sandboxd never became healthy"; }
+log "sandboxd healthy"
+
+# 2. Default create -> react-standard seeded -> dev server installs + serves 200.
+log "create (default template) -> preview returns 200"
+ID="$(mk '{"ports":[3000]}')"; [ -n "$ID" ] || fail "create returned no id"; IDS+=("$ID")
+IP="$(ipof "$ID")"; [ -n "$IP" ] || fail "no container IP for $ID"
+up=""
+for i in $(seq 1 90); do
+  [ "$(curl -s -m3 -o /dev/null -w '%{http_code}' "http://$IP:3000/" 2>/dev/null)" = "200" ] && { up=1; break; }
+  sleep 3
+done
+[ -n "$up" ] || { docker logs "s-$ID" 2>&1 | tail -25; fail "preview never returned 200"; }
+log "preview 200 ✓"
+
+# 3. template:blank -> empty workspace/app.
+log "create (template=blank) -> empty app"
+IDB="$(mk '{"ports":[3000],"template":"blank"}')"; [ -n "$IDB" ] || fail "blank create returned no id"; IDS+=("$IDB")
+sleep 5
+[ -z "$(ls -A "$DD/workspaces/$IDB/workspace/app" 2>/dev/null)" ] || fail "template=blank produced a non-empty app"
+log "blank empty ✓"
+
+# 4. Invalid create payload -> 400 (no partial state).
+log "invalid create payload -> 400"
+code="$(curl -s -m10 -o /dev/null -w '%{http_code}' -XPOST "$API/sandbox" -H 'content-type: application/json' -d '{"ports":"nope"}')"
+[ "$code" = "400" ] || fail "bad payload returned $code, want 400"
+log "bad payload 400 ✓"
+
+# 5. Stop -> submit task -> wakes to running (wake path, no model needed).
+log "stopped sandbox -> submit task -> wakes"
+curl -s -m20 -o /dev/null -XPOST "$API/v1/sandboxes/$ID/stop"
+for i in $(seq 1 15); do [ "$(status "$ID")" = "stopped" ] && break; sleep 1; done
+[ "$(status "$ID")" = "stopped" ] || log "warn: sandbox not 'stopped' before wake test"
+curl -s -m60 -o /dev/null -XPOST "$API/v1/sandboxes/$ID/tasks" -H 'content-type: application/json' -d '{"prompt":"noop","timeout_s":30}' || true
+woke=""
+for i in $(seq 1 25); do [ "$(status "$ID")" = "running" ] && { woke=1; break; }; sleep 2; done
+[ -n "$woke" ] || fail "sandbox did not wake on task submit"
+log "wake-on-task ✓"
+
+echo "✅ E2E PASSED"


### PR DESCRIPTION
## Why

CI only ran gofmt/build/unit tests, so whole classes of regression shipped green — a PR could drop OpenCode or the `react-standard` template from the image, or break the create→serve→wake lifecycle, and nothing caught it. (Two near-misses this cycle: #18 nearly removed OpenCode; the template-seed regression where a stray `.gitkeep` silently disabled seeding.)

## What

New **`e2e` job** builds the base image + sandboxd and runs `scripts/e2e.sh` against a real Docker daemon — **no model creds needed**, so it's deterministic:
- **image smoke**: `runtimed`/`opencode`/`claude`/`node`/`pnpm`/`git`/`rg` on PATH + `react-standard` template present
- **default create → preview HTTP 200** (exercises provision → seed → `pnpm install` → vite → serve)
- **`template=blank` → empty** `workspace/app`
- **invalid create payload → 400**
- **stopped sandbox → submit task → wakes to running**

Also adds `go vet ./...` to the `go` job.

`scripts/e2e.sh` runs locally too: `SANDBOXD_IMAGE=... SANDBOXD_BIN=... sudo -E bash scripts/e2e.sh` — **verified passing locally end-to-end** before pushing.

Maps to the Phase-0 test plan: E2E fresh-install create→task→preview-200, stopped→wake, template create, bad-payload 400, and CI image smoke.