### PR TITLE
feat(apps): durable app entities above sandboxes (Phase 1)

### DIFF
--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -141,6 +141,13 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /v1/sandboxes/{id}/files", s.observe("PUT /v1/sandboxes/{id}/files", s.v1PutFile))
 	mux.HandleFunc("GET /v1/sandboxes/{id}/export", s.observe("GET /v1/sandboxes/{id}/export", s.v1Export))
 
+	// Durable apps above sandboxes (Phase 1).
+	mux.HandleFunc("POST /v1/apps", s.observe("POST /v1/apps", s.v1CreateApp))
+	mux.HandleFunc("GET /v1/apps", s.observe("GET /v1/apps", s.v1ListApps))
+	mux.HandleFunc("GET /v1/apps/{id}", s.observe("GET /v1/apps/{id}", s.v1GetApp))
+	mux.HandleFunc("PATCH /v1/apps/{id}", s.observe("PATCH /v1/apps/{id}", s.v1PatchApp))
+	mux.HandleFunc("POST /v1/apps/{id}/sandbox", s.observe("POST /v1/apps/{id}/sandbox", s.v1CreateAppSandbox))
+
 	// Snapshots-as-templates (ops/design/snapshots-as-templates.md).
 	mux.HandleFunc("POST /v1/snapshots", s.observe("POST /v1/snapshots", s.v1CreateSnapshot))
 	mux.HandleFunc("GET /v1/snapshots", s.observe("GET /v1/snapshots", s.v1ListSnapshots))

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -71,6 +71,10 @@ type createReq struct {
 	//   reaping. NOTE: still stoppable under critical host pressure (<5% mem
 	//   available), and not auto-restarted if stopped.
 	IdlePolicy string `json:"idle_policy,omitempty"`
+	// AppID links this sandbox to a durable app (Phase 1). Set by the
+	// POST /v1/apps/{id}/sandbox path; empty for the standalone sandbox
+	// API. The sandbox is the app's current running instance.
+	AppID string `json:"app_id,omitempty"`
 }
 
 type sandboxResp struct {
@@ -440,6 +444,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		ExternalUserID:      nullStr(req.External.UserID),
 		ExternalProjectID:   nullStr(req.External.ProjectID),
 		ExternalWorkspaceID: nullStr(req.External.WorkspaceID),
+		AppID:               nullStr(req.AppID),
 	}
 	if err := s.Store.Create(r.Context(), sb); err != nil {
 		if errors.Is(err, store.ErrConflict) {

--- a/control-plane/internal/api/v1_apps.go
+++ b/control-plane/internal/api/v1_apps.go
@@ -1,0 +1,217 @@
+// v1_apps.go — durable "app" entities above sandboxes (Phase 1).
+// An app owns the user-facing concept (name/description/tags) and
+// outlives its sandbox. Scoped to the API tenant (auth.Actor.Name);
+// external_* are optional integration tags. The sandbox link lives on
+// the sandbox (app_id), so an app's "current sandbox" is derived.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/store"
+)
+
+type v1App struct {
+	ID                string   `json:"id"`
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	Tags              []string `json:"tags"`
+	ExternalUserID    string   `json:"external_user_id,omitempty"`
+	ExternalProjectID string   `json:"external_project_id,omitempty"`
+	CurrentSandboxID  string   `json:"current_sandbox_id,omitempty"`
+	CreatedAt         string   `json:"created_at"`
+	UpdatedAt         string   `json:"updated_at"`
+}
+
+func v1AppFromRow(a *store.App, currentSandboxID string) v1App {
+	out := v1App{
+		ID:               a.ID,
+		Name:             a.Name,
+		Description:      a.Description,
+		Tags:             a.Tags,
+		CurrentSandboxID: currentSandboxID,
+		CreatedAt:        a.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:        a.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if out.Tags == nil {
+		out.Tags = []string{}
+	}
+	if a.ExternalUserID.Valid {
+		out.ExternalUserID = a.ExternalUserID.String
+	}
+	if a.ExternalProjectID.Valid {
+		out.ExternalProjectID = a.ExternalProjectID.String
+	}
+	return out
+}
+
+// currentSandboxID returns the app's current sandbox id, or "" if none.
+func (s *Server) currentSandboxID(r *http.Request, appID string) string {
+	sb, err := s.Store.CurrentSandboxForApp(r.Context(), appID)
+	if err != nil {
+		return ""
+	}
+	return sb.ID
+}
+
+type v1CreateAppReq struct {
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	Tags              []string `json:"tags"`
+	ExternalUserID    string   `json:"external_user_id"`
+	ExternalProjectID string   `json:"external_project_id"`
+}
+
+// v1CreateApp — POST /v1/apps.
+func (s *Server) v1CreateApp(w http.ResponseWriter, r *http.Request) {
+	var req v1CreateAppReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid json: "+err.Error())
+		return
+	}
+	if req.Name == "" {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "name is required")
+		return
+	}
+	app := &store.App{
+		ID:                newULID(),
+		OwnerToken:        tenantToken(r),
+		Name:              req.Name,
+		Description:       req.Description,
+		Tags:              req.Tags,
+		ExternalUserID:    nullStr(req.ExternalUserID),
+		ExternalProjectID: nullStr(req.ExternalProjectID),
+	}
+	if err := s.Store.CreateApp(r.Context(), app); err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	s.auditAction(r, audit.Entry{Action: "app.create", Target: app.ID})
+	writeJSON(w, http.StatusCreated, v1AppFromRow(app, ""))
+}
+
+// v1ListApps — GET /v1/apps (tenant-scoped; optional ?external_user_id).
+func (s *Server) v1ListApps(w http.ResponseWriter, r *http.Request) {
+	apps, err := s.Store.ListAppsForOwner(r.Context(), tenantToken(r), r.URL.Query().Get("external_user_id"))
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	out := make([]v1App, 0, len(apps))
+	for _, a := range apps {
+		out = append(out, v1AppFromRow(a, s.currentSandboxID(r, a.ID)))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"apps": out})
+}
+
+// v1GetApp — GET /v1/apps/{id}.
+func (s *Server) v1GetApp(w http.ResponseWriter, r *http.Request) {
+	app, err := s.Store.GetAppForOwner(r.Context(), r.PathValue("id"), tenantToken(r))
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such app")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, v1AppFromRow(app, s.currentSandboxID(r, app.ID)))
+}
+
+type v1PatchAppReq struct {
+	Name        *string   `json:"name"`
+	Description *string   `json:"description"`
+	Tags        *[]string `json:"tags"`
+}
+
+// v1PatchApp — PATCH /v1/apps/{id}.
+func (s *Server) v1PatchApp(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req v1PatchAppReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid json: "+err.Error())
+		return
+	}
+	if req.Name != nil && *req.Name == "" {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "name cannot be empty")
+		return
+	}
+	err := s.Store.UpdateApp(r.Context(), id, tenantToken(r), store.AppPatch{
+		Name: req.Name, Description: req.Description, Tags: req.Tags,
+	})
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such app")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	app, err := s.Store.GetAppForOwner(r.Context(), id, tenantToken(r))
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	s.auditAction(r, audit.Entry{Action: "app.update", Target: id})
+	writeJSON(w, http.StatusOK, v1AppFromRow(app, s.currentSandboxID(r, id)))
+}
+
+type v1CreateAppSandboxReq struct {
+	Template string `json:"template,omitempty"`
+	Ports    []int  `json:"ports,omitempty"`
+}
+
+// v1CreateAppSandbox — POST /v1/apps/{id}/sandbox. Creates the app's
+// current sandbox (one live sandbox per app for now). Delegates to the
+// proven internal create path with the app's id + integration tags.
+func (s *Server) v1CreateAppSandbox(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	app, err := s.Store.GetAppForOwner(r.Context(), id, tenantToken(r))
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such app")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if cur, cerr := s.Store.CurrentSandboxForApp(r.Context(), id); cerr == nil {
+		writeV1Err(w, http.StatusConflict, "conflict",
+			"app already has a sandbox ("+cur.ID+"); delete it first")
+		return
+	}
+
+	var req v1CreateAppSandboxReq
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req) // body optional
+	}
+	ports := req.Ports
+	if len(ports) == 0 {
+		ports = []int{3000}
+	}
+	createBody := map[string]any{
+		"ports":  ports,
+		"app_id": app.ID,
+		"external": map[string]string{
+			"user_id":    app.ExternalUserID.String,
+			"project_id": app.ExternalProjectID.String,
+		},
+	}
+	if req.Template != "" {
+		createBody["template"] = req.Template
+	}
+	internal, _ := json.Marshal(createBody)
+	code, body := s.delegate(r, s.handleCreate, http.MethodPost, "/sandbox", nil, internal)
+	if code != http.StatusCreated {
+		relayV1Error(w, code, body)
+		return
+	}
+	s.auditAction(r, audit.Entry{Action: "app.sandbox.create", Target: app.ID})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_, _ = w.Write(body)
+}

--- a/control-plane/internal/store/apps.go
+++ b/control-plane/internal/store/apps.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// App is a durable product entity above sandboxes (migrations/0013).
+// It owns the user-facing concept and outlives the sandbox that is its
+// current running instance. external_* are optional integration tags.
+type App struct {
+	ID                string
+	OwnerToken        string
+	ExternalUserID    sql.NullString
+	ExternalProjectID sql.NullString
+	Name              string
+	Description       string
+	Tags              []string
+	LatestSnapshotID  sql.NullString
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+// AppPatch carries the fields a PATCH may change; nil means "leave as-is".
+type AppPatch struct {
+	Name        *string
+	Description *string
+	Tags        *[]string
+}
+
+func marshalTags(tags []string) string {
+	if tags == nil {
+		tags = []string{}
+	}
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func scanApp(sc scanner) (*App, error) {
+	a := &App{}
+	var tags string
+	var created, updated int64
+	err := sc.Scan(&a.ID, &a.OwnerToken, &a.ExternalUserID, &a.ExternalProjectID,
+		&a.Name, &a.Description, &tags, &a.LatestSnapshotID, &created, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal([]byte(tags), &a.Tags)
+	if a.Tags == nil {
+		a.Tags = []string{}
+	}
+	a.CreatedAt = time.Unix(created, 0).UTC()
+	a.UpdatedAt = time.Unix(updated, 0).UTC()
+	return a, nil
+}
+
+const appSelectCols = `id, owner_token, external_user_id, external_project_id,
+	       name, description, tags, latest_snapshot_id, created_at, updated_at`
+
+// CreateApp inserts a new app. The caller sets ID (ULID) and OwnerToken.
+func (s *Store) CreateApp(ctx context.Context, a *App) error {
+	return s.submit(ctx, func(db *sql.DB) error {
+		now := time.Now().Unix()
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO app (id, owner_token, external_user_id, external_project_id,
+			                 name, description, tags, latest_snapshot_id,
+			                 created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			a.ID, a.OwnerToken, a.ExternalUserID, a.ExternalProjectID,
+			a.Name, a.Description, marshalTags(a.Tags), a.LatestSnapshotID, now, now)
+		if err != nil {
+			if isUniqueViolation(err) {
+				return ErrConflict
+			}
+			return err
+		}
+		a.CreatedAt = time.Unix(now, 0).UTC()
+		a.UpdatedAt = a.CreatedAt
+		return nil
+	})
+}
+
+// GetAppForOwner returns an app scoped to the tenant. A missing or
+// cross-tenant app is ErrNotFound (don't leak existence across tenants).
+func (s *Store) GetAppForOwner(ctx context.Context, id, ownerToken string) (*App, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+appSelectCols+` FROM app WHERE id = ? AND owner_token = ?`, id, ownerToken)
+	return scanApp(row)
+}
+
+// ListAppsForOwner lists a tenant's apps, optionally filtered by the
+// external_user_id integration tag (empty = no constraint).
+func (s *Store) ListAppsForOwner(ctx context.Context, ownerToken, externalUserID string) ([]*App, error) {
+	q := `SELECT ` + appSelectCols + ` FROM app WHERE owner_token = ?`
+	args := []any{ownerToken}
+	if externalUserID != "" {
+		q += ` AND external_user_id = ?`
+		args = append(args, externalUserID)
+	}
+	q += ` ORDER BY created_at DESC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*App
+	for rows.Next() {
+		a, err := scanApp(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// UpdateApp applies a partial update scoped to the tenant. Returns
+// ErrNotFound when no app matches (id, ownerToken).
+func (s *Store) UpdateApp(ctx context.Context, id, ownerToken string, patch AppPatch) error {
+	return s.submit(ctx, func(db *sql.DB) error {
+		sets := []string{}
+		args := []any{}
+		if patch.Name != nil {
+			sets = append(sets, "name = ?")
+			args = append(args, *patch.Name)
+		}
+		if patch.Description != nil {
+			sets = append(sets, "description = ?")
+			args = append(args, *patch.Description)
+		}
+		if patch.Tags != nil {
+			sets = append(sets, "tags = ?")
+			args = append(args, marshalTags(*patch.Tags))
+		}
+		// Always bump updated_at; an empty patch is a touch.
+		sets = append(sets, "updated_at = ?")
+		args = append(args, time.Now().Unix())
+		q := "UPDATE app SET " + joinComma(sets) + " WHERE id = ? AND owner_token = ?"
+		args = append(args, id, ownerToken)
+		res, err := db.ExecContext(ctx, q, args...)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// CurrentSandboxForApp returns the app's current (non-deleted) sandbox,
+// or ErrNotFound when the app has none. A DELETE removes the sandbox
+// row, so any remaining row is the current instance.
+func (s *Store) CurrentSandboxForApp(ctx context.Context, appID string) (*Sandbox, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+sandboxSelectCols+` FROM sandbox WHERE app_id = ? ORDER BY created_at DESC LIMIT 1`, appID)
+	sb, err := scanSandbox(row)
+	if err != nil {
+		return nil, err
+	}
+	sb.Ports, _ = s.portsFor(ctx, sb.ID)
+	return sb, nil
+}
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}

--- a/control-plane/internal/store/apps_test.go
+++ b/control-plane/internal/store/apps_test.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+)
+
+func TestAppCRUDAndScoping(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	a := &App{
+		ID: "01APP0000000000000000000A1", OwnerToken: "tenant-1",
+		Name: "My App", Description: "d", Tags: []string{"web", "demo"},
+		ExternalUserID: sql.NullString{String: "u1", Valid: true},
+	}
+	if err := st.CreateApp(ctx, a); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stable ID + full readback (incl. tags round-trip).
+	got, err := st.GetAppForOwner(ctx, a.ID, "tenant-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != a.ID || got.Name != "My App" || len(got.Tags) != 2 {
+		t.Errorf("readback mismatch: %+v", got)
+	}
+
+	// Cross-tenant get is ErrNotFound (no existence leak).
+	if _, err := st.GetAppForOwner(ctx, a.ID, "tenant-2"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("cross-tenant get = %v; want ErrNotFound", err)
+	}
+
+	// List is tenant-scoped, with an optional external_user_id filter.
+	_ = st.CreateApp(ctx, &App{ID: "01APP0000000000000000000B2", OwnerToken: "tenant-1",
+		Name: "B", ExternalUserID: sql.NullString{String: "u2", Valid: true}})
+	_ = st.CreateApp(ctx, &App{ID: "01APP0000000000000000000C3", OwnerToken: "tenant-2", Name: "C"})
+
+	t1, _ := st.ListAppsForOwner(ctx, "tenant-1", "")
+	if len(t1) != 2 {
+		t.Errorf("tenant-1 apps = %d; want 2 (no tenant-2 leakage)", len(t1))
+	}
+	filtered, _ := st.ListAppsForOwner(ctx, "tenant-1", "u1")
+	if len(filtered) != 1 || filtered[0].ID != a.ID {
+		t.Errorf("external_user_id filter = %+v; want only %s", filtered, a.ID)
+	}
+
+	// Partial PATCH, tenant-scoped.
+	newName := "Renamed"
+	if err := st.UpdateApp(ctx, a.ID, "tenant-1", AppPatch{Name: &newName}); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := st.GetAppForOwner(ctx, a.ID, "tenant-1")
+	if got2.Name != "Renamed" || got2.Description != "d" {
+		t.Errorf("patch: name=%q desc=%q; want Renamed/d", got2.Name, got2.Description)
+	}
+	if err := st.UpdateApp(ctx, a.ID, "tenant-2", AppPatch{Name: &newName}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("cross-tenant patch = %v; want ErrNotFound", err)
+	}
+}
+
+// The core Phase-1 guarantee: an app outlives its sandbox.
+func TestAppSurvivesSandboxDelete(t *testing.T) {
+	st := openTestStore(t)
+	ctx := context.Background()
+
+	app := &App{ID: "01APPSURV0000000000000001", OwnerToken: "t", Name: "App"}
+	if err := st.CreateApp(ctx, app); err != nil {
+		t.Fatal(err)
+	}
+
+	// No sandbox yet → no current.
+	if _, err := st.CurrentSandboxForApp(ctx, app.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("current with no sandbox = %v; want ErrNotFound", err)
+	}
+
+	// Attach a sandbox to the app.
+	sb := minimalSandbox("01SBXAPP00000000000000001", "sleep")
+	sb.AppID = sql.NullString{String: app.ID, Valid: true}
+	if err := st.Create(ctx, sb); err != nil {
+		t.Fatal(err)
+	}
+	cur, err := st.CurrentSandboxForApp(ctx, app.ID)
+	if err != nil || cur.ID != sb.ID {
+		t.Fatalf("current sandbox = %v, %v; want %s", cur, err, sb.ID)
+	}
+
+	// Delete the sandbox — app + its metadata survive; current becomes none.
+	if err := st.Delete(ctx, sb.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CurrentSandboxForApp(ctx, app.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("current after sandbox delete = %v; want ErrNotFound", err)
+	}
+	survived, err := st.GetAppForOwner(ctx, app.ID, "t")
+	if err != nil || survived.Name != "App" {
+		t.Errorf("app must survive sandbox delete; got %v, %v", survived, err)
+	}
+}

--- a/control-plane/internal/store/store.go
+++ b/control-plane/internal/store/store.go
@@ -56,6 +56,11 @@ type Sandbox struct {
 	ExternalProjectID   sql.NullString
 	ExternalWorkspaceID sql.NullString
 	Visibility          string
+
+	// Phase 1 — the durable app this sandbox is the current instance of
+	// (migrations/0013_apps.sql). NULL for sandboxes created outside the
+	// app model (the existing sandbox API).
+	AppID sql.NullString
 }
 
 // WorkspaceOwner is the durable sandbox_id -> upstream-identity
@@ -136,7 +141,7 @@ func (s *Store) Get(ctx context.Context, id string) (*Sandbox, error) {
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
 		       external_user_id, external_project_id, external_workspace_id, visibility,
-		       idle_policy
+		       idle_policy, app_id
 		  FROM sandbox WHERE id = ?`, id)
 	sb, err := scanSandbox(row)
 	if err != nil {
@@ -158,7 +163,7 @@ func (s *Store) List(ctx context.Context) ([]*Sandbox, error) {
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
 		       external_user_id, external_project_id, external_workspace_id, visibility,
-		       idle_policy
+		       idle_policy, app_id
 		  FROM sandbox ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
@@ -194,7 +199,7 @@ func (s *Store) ListByStatuses(ctx context.Context, statuses ...string) ([]*Sand
 	             last_active_at, stopped_at, keepalive_until,
 	             container_ip,
 	             external_user_id, external_project_id, external_workspace_id, visibility,
-	             idle_policy
+	             idle_policy, app_id
 	        FROM sandbox WHERE status IN (?`
 	args := make([]any, 0, len(statuses))
 	args = append(args, statuses[0])
@@ -239,7 +244,7 @@ func (s *Store) ListIdleCandidates(ctx context.Context, cutoff time.Time) ([]*Sa
 		       last_active_at, stopped_at, keepalive_until,
 		       container_ip,
 		       external_user_id, external_project_id, external_workspace_id, visibility,
-		       idle_policy
+		       idle_policy, app_id
 		  FROM sandbox
 		 WHERE status='running' AND last_active_at < ? AND idle_policy != 'always_on'
 		 ORDER BY last_active_at ASC`, cutoff.Unix())
@@ -292,6 +297,7 @@ func scanSandbox(s scanner) (*Sandbox, error) {
 		&sb.ContainerIP,
 		&sb.ExternalUserID, &sb.ExternalProjectID, &sb.ExternalWorkspaceID, &sb.Visibility,
 		&sb.IdlePolicy,
+		&sb.AppID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
@@ -318,7 +324,7 @@ const sandboxSelectCols = `id, status, image, workspace_img, workspace_mnt,
 	       last_active_at, stopped_at, keepalive_until,
 	       container_ip,
 	       external_user_id, external_project_id, external_workspace_id, visibility,
-	       idle_policy`
+	       idle_policy, app_id`
 
 // ListFiltered returns sandbox rows filtered by external_user_id and/
 // or external_project_id. An empty string for either filter means "do

--- a/control-plane/internal/store/writer.go
+++ b/control-plane/internal/store/writer.go
@@ -86,11 +86,12 @@ func (s *Store) Create(ctx context.Context, sb *Sandbox) error {
 			                    created_at, updated_at,
 			                    external_user_id, external_project_id,
 			                    external_workspace_id, visibility,
-			                    idle_policy)
-			VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?, ?, ?, ?, ?, ?)`,
+			                    idle_policy, app_id)
+			VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			sb.ID, sb.Status, sb.Image, sb.WorkspaceImg, sb.WorkspaceMnt,
 			sb.MemoryHigh, now, now,
-			sb.ExternalUserID, sb.ExternalProjectID, sb.ExternalWorkspaceID, visibility, idlePolicy)
+			sb.ExternalUserID, sb.ExternalProjectID, sb.ExternalWorkspaceID, visibility, idlePolicy,
+			sb.AppID)
 
 		if err != nil {
 			if isUniqueViolation(err) {

--- a/control-plane/migrations/0013_apps.sql
+++ b/control-plane/migrations/0013_apps.sql
@@ -1,0 +1,25 @@
+-- Phase 1: durable "app" entities above sandboxes. An app owns the
+-- user-facing concept (name/description/tags) and outlives the sandbox
+-- that is its current running instance. external_* are optional
+-- integration tags (an app may map 1:1 to an upstream project); the
+-- canonical entity is the app. Additive + backwards-compatible: existing
+-- sandboxes have a NULL app_id and the sandbox API is unchanged.
+CREATE TABLE app (
+    id                  TEXT PRIMARY KEY,         -- ULID
+    owner_token         TEXT NOT NULL,            -- tenant (auth.Actor.Name)
+    external_user_id    TEXT,                     -- optional integration tag
+    external_project_id TEXT,                     -- optional integration tag
+    name                TEXT NOT NULL,
+    description         TEXT NOT NULL DEFAULT '',
+    tags                TEXT NOT NULL DEFAULT '[]', -- JSON array of strings
+    latest_snapshot_id  TEXT,                     -- recreate-from-snapshot (future)
+    created_at          INTEGER NOT NULL,
+    updated_at          INTEGER NOT NULL
+);
+CREATE INDEX idx_app_owner ON app(owner_token);
+
+-- The link lives on the sandbox (single source of truth). "Current
+-- sandbox" = the app's non-deleted sandbox row; on DELETE the row is
+-- removed, so the app simply has no current sandbox.
+ALTER TABLE sandbox ADD COLUMN app_id TEXT;
+CREATE INDEX idx_sandbox_app_id ON sandbox(app_id);

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -95,4 +95,21 @@ for i in $(seq 1 25); do [ "$(status "$ID")" = "running" ] && { woke=1; break; }
 [ -n "$woke" ] || fail "sandbox did not wake on task submit"
 log "wake-on-task ✓"
 
+# 6. App model: a durable app above sandboxes (create → attach → survive).
+log "app: create → attach sandbox → 409 on second → survives delete"
+APP="$(curl -s -m10 -XPOST "$API/v1/apps" -H 'content-type: application/json' -d '{"name":"E2E App","tags":["e2e"]}' | grep -oE '"id":"[^"]+"' | head -1 | cut -d'"' -f4)"
+[ -n "$APP" ] || fail "create app returned no id"
+curl -s -m10 "$API/v1/apps" | grep -q "\"$APP\"" || fail "app not in tenant list"
+sbcode="$(curl -s -m120 -o /tmp/appsb.json -w '%{http_code}' -XPOST "$API/v1/apps/$APP/sandbox" -H 'content-type: application/json' -d '{}')"
+[ "$sbcode" = "201" ] || { cat /tmp/appsb.json; fail "attach sandbox returned $sbcode, want 201"; }
+ASB="$(grep -oE '"id":"[^"]+"' /tmp/appsb.json | head -1 | cut -d'"' -f4)"; IDS+=("$ASB")
+curl -s -m10 "$API/v1/apps/$APP" | grep -q "\"current_sandbox_id\":\"$ASB\"" || fail "app current_sandbox_id not set"
+dup="$(curl -s -m10 -o /dev/null -w '%{http_code}' -XPOST "$API/v1/apps/$APP/sandbox" -H 'content-type: application/json' -d '{}')"
+[ "$dup" = "409" ] || fail "second attach returned $dup, want 409 (one live sandbox per app)"
+curl -s -m30 -o /dev/null -XPOST "$API/sandbox/$ASB/purge"
+sleep 2
+curl -s -m10 "$API/v1/apps/$APP" | grep -q "\"id\":\"$APP\"" || fail "app did not survive sandbox delete"
+curl -s -m10 "$API/v1/apps/$APP" | grep -q 'current_sandbox_id' && fail "current_sandbox_id present after delete"
+log "app lifecycle ✓"
+
 echo "✅ E2E PASSED"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -106,10 +106,14 @@ ASB="$(grep -oE '"id":"[^"]+"' /tmp/appsb.json | head -1 | cut -d'"' -f4)"; IDS+
 curl -s -m10 "$API/v1/apps/$APP" | grep -q "\"current_sandbox_id\":\"$ASB\"" || fail "app current_sandbox_id not set"
 dup="$(curl -s -m10 -o /dev/null -w '%{http_code}' -XPOST "$API/v1/apps/$APP/sandbox" -H 'content-type: application/json' -d '{}')"
 [ "$dup" = "409" ] || fail "second attach returned $dup, want 409 (one live sandbox per app)"
-curl -s -m30 -o /dev/null -XPOST "$API/sandbox/$ASB/purge"
-sleep 2
+curl -s -m60 -o /dev/null -XDELETE "$API/sandbox/$ASB"
+gone=""
+for i in $(seq 1 30); do
+  curl -s -m10 "$API/v1/apps/$APP" | grep -q 'current_sandbox_id' || { gone=1; break; }
+  sleep 1
+done
+[ -n "$gone" ] || fail "current_sandbox_id still present after sandbox delete"
 curl -s -m10 "$API/v1/apps/$APP" | grep -q "\"id\":\"$APP\"" || fail "app did not survive sandbox delete"
-curl -s -m10 "$API/v1/apps/$APP" | grep -q 'current_sandbox_id' && fail "current_sandbox_id present after delete"
 log "app lifecycle ✓"
 
 echo "✅ E2E PASSED"


### PR DESCRIPTION
## Goal
Introduce **apps** as the canonical, durable product entity above sandboxes. An app owns the user-facing concept (name/description/tags) and **outlives** the sandbox that is its current running instance. Additive + backwards-compatible — existing sandboxes have a `NULL app_id` and the sandbox API is unchanged.

## Model (per the approved design)
- **`app` table** (migration `0013`): `id`, `owner_token` (tenant), optional `external_user_id`/`external_project_id` **integration tags**, `name`, `description`, `tags` (JSON), `latest_snapshot_id`, timestamps.
- **The link lives on the sandbox**: nullable `sandbox.app_id` (single source of truth — avoids the two-way-pointer trap). "Current sandbox" = the app's non-deleted sandbox row; `DELETE` removes the row, so the app simply has no current sandbox → *"app survives sandbox destroy" is automatic*.
- **Scoping mirrors snapshots**: `owner_token` tenant + optional `external_user_id` filter. `workspace_owner` untouched (first pass, as agreed).

## API (all tenant-scoped)
`POST /v1/apps` · `GET /v1/apps?external_user_id=` · `GET /v1/apps/{id}` · `PATCH /v1/apps/{id}` · `POST /v1/apps/{id}/sandbox`

App-sandbox create **delegates to the proven internal create path** with the app's id + integration tags. One live sandbox per app for now (409 if one exists).

## Tests
- **store**: CRUD, tenant scoping (cross-tenant → not found, no existence leak), `external_user_id` filter, partial PATCH, and the **core guarantee** — an app survives its sandbox's deletion (`current` → none, metadata intact).
- **e2e.sh**: create app → attach sandbox (201) → `current_sandbox_id` set → **409 on second attach** → purge → **app survives**. Verified live.
- Existing sandbox tests still pass (`app_id` threaded through the shared scan + all four hardcoded SELECTs + the Create insert — caught and fixed a 20-vs-21-column mismatch via the suite).

## Maps to Phase-1 exit criteria
The system can now show an **app list** (`GET /v1/apps`) without treating containers as the product.

`go build` / `go vet` / `gofmt` / `go test ./...` all clean.