### PR TITLE
feat(console): add an optional web console + /v1 OpenAPI spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,11 @@ jobs:
           SANDBOXD_IMAGE: sandboxed-base:ci
           SANDBOXD_BIN: /tmp/sandboxd
         run: bash scripts/e2e.sh
+
+  # Build the console SPA + image so a TypeScript or build break is caught.
+  console:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build console image
+        run: docker build -t sandboxd-console:ci ./console

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, console]
   pull_request:
 
 jobs:

--- a/console/.dockerignore
+++ b/console/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+test-results
+playwright-report
+.git

--- a/console/.gitignore
+++ b/console/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+test-results
+playwright-report
+.playwright

--- a/console/.gitignore
+++ b/console/.gitignore
@@ -3,3 +3,4 @@ dist
 test-results
 playwright-report
 .playwright
+.pnpm-store

--- a/console/Dockerfile
+++ b/console/Dockerfile
@@ -1,0 +1,13 @@
+# Build the SPA, then serve it from nginx with /v1 proxied to sandboxd.
+FROM node:20-slim AS build
+RUN corepack enable
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm build
+
+FROM nginx:stable-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/console/README.md
+++ b/console/README.md
@@ -1,0 +1,40 @@
+# sandboxd console
+
+An optional web console for managing **apps** on top of sandboxd — see your
+apps, open one, view its live preview, submit agent tasks, watch task logs, and
+start/stop/snapshot its sandbox.
+
+A Vite + React SPA. It talks **only** to the public sandboxd `/v1` API
+(`docs/openapi.yaml`) — no Go imports, no database, no workspace access. That
+boundary is deliberate: once `/v1` stabilizes, this folder splits cleanly into a
+standalone `sandboxd-console` repo.
+
+## Run it (console mode)
+
+From the repo root:
+
+```bash
+docker compose --profile console up
+```
+
+Then open the console at <http://127.0.0.1:8787>. Core mode (`docker compose up`,
+no profile) runs sandboxd without the console.
+
+The console container serves the built SPA from nginx and proxies `/v1` to the
+`sandboxd` service on the internal network, so the browser uses same-origin
+relative paths — no CORS, and no auth in the single-user default.
+
+## Develop
+
+```bash
+pnpm install
+pnpm dev            # http://127.0.0.1:8787, proxies /v1 to $SANDBOXD_URL (default 127.0.0.1:9090)
+pnpm build
+pnpm test:e2e       # Playwright — needs the stack up (see above)
+```
+
+## Scope (MVP)
+
+Single-user, auth-off, public previews. Multi-user auth, private-preview
+embedding, and a richer UI come later. The console assumes a local/loopback
+sandboxd.

--- a/console/README.md
+++ b/console/README.md
@@ -17,12 +17,14 @@ From the repo root:
 docker compose --profile console up
 ```
 
-Then open the console at <http://127.0.0.1:8787>. Core mode (`docker compose up`,
-no profile) runs sandboxd without the console.
+Then open <http://console.localhost> (or `console.<PREVIEW_DOMAIN>:<HTTP_PORT>`).
+Core mode (`docker compose up`, no profile) runs sandboxd without the console.
 
-The console container serves the built SPA from nginx and proxies `/v1` to the
+The console is routed through the **same Traefik as the previews**, by Host
+header — `console.<domain>` → console, `*.preview.<domain>` → sandboxes — so it
+shares one entrypoint. nginx serves the built SPA and proxies `/v1` to the
 `sandboxd` service on the internal network, so the browser uses same-origin
-relative paths — no CORS, and no auth in the single-user default.
+relative paths: no CORS, and no auth in the single-user default.
 
 ## Develop
 

--- a/console/e2e/console.spec.ts
+++ b/console/e2e/console.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+// These drive the real console + sandboxd stack
+// (docker compose --profile console up). The lifecycle test creates a
+// sandbox, which builds + installs on first boot, so it is slow.
+
+test('app list loads', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByRole('heading', { name: 'Apps' })).toBeVisible()
+  await expect(page.getByTestId('create-app')).toBeVisible()
+})
+
+test('create app from the UI', async ({ page }) => {
+  await page.goto('/')
+  const name = `e2e-${Date.now()}`
+  await page.getByTestId('app-name').fill(name)
+  await page.getByTestId('create-app').click()
+  // Navigates to the new app's detail.
+  await expect(page.getByRole('heading', { name })).toBeVisible()
+  await expect(page.getByTestId('create-sandbox')).toBeVisible()
+})
+
+test('full lifecycle: sandbox → preview → task → stop/start', async ({ page }) => {
+  test.slow()
+  await page.goto('/')
+  const name = `e2e-life-${Date.now()}`
+  await page.getByTestId('app-name').fill(name)
+  await page.getByTestId('create-app').click()
+  await expect(page.getByRole('heading', { name })).toBeVisible()
+
+  // Create the app's sandbox.
+  await page.getByTestId('create-sandbox').click()
+
+  // Preview iframe appears once the dev server is up (install + vite).
+  await expect(page.getByTestId('preview')).toBeVisible({ timeout: 90_000 })
+  await expect(page.getByTestId('status')).toContainText('running')
+
+  // Submit a task and see a status badge appear (running → terminal).
+  await page.getByTestId('task-prompt').fill('say hello')
+  await page.getByTestId('run-task').click()
+  await expect(page.getByTestId('task-status')).toBeVisible({ timeout: 30_000 })
+
+  // Stop → state flips to stopped; Start brings it back.
+  await page.getByTestId('stop').click()
+  await expect(page.getByTestId('status')).toContainText('stopped', { timeout: 30_000 })
+  await page.getByTestId('start').click()
+  await expect(page.getByTestId('status')).toContainText('running', { timeout: 60_000 })
+})

--- a/console/index.html
+++ b/console/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sandboxd console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: serve index.html for client-side routes.
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # API-only boundary: proxy the public /v1 API to sandboxd. Resolve the
+    # upstream at request time (Docker's embedded DNS) via a variable, so
+    # nginx starts even if sandboxd isn't up yet and survives its restarts.
+    # SSE needs buffering off + a long read timeout for live task logs.
+    location /v1/ {
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $sandboxd_upstream "sandboxd:9000";
+        proxy_pass http://$sandboxd_upstream$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 1h;
+    }
+}

--- a/console/package.json
+++ b/console/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "sandboxd-console",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "packageManager": "pnpm@9.15.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --host --port 8787",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.2",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/console/playwright.config.ts
+++ b/console/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+
+// Runs against a live console (which proxies to a live sandboxd). Bring
+// the stack up first:  docker compose --profile console up -d
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 120_000,
+  expect: { timeout: 10_000 },
+  reporter: 'list',
+  use: {
+    baseURL: process.env.CONSOLE_URL || 'http://127.0.0.1:8787',
+    trace: 'on-first-retry',
+  },
+})

--- a/console/playwright.config.ts
+++ b/console/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   expect: { timeout: 10_000 },
   reporter: 'list',
   use: {
-    baseURL: process.env.CONSOLE_URL || 'http://127.0.0.1:8787',
+    baseURL: process.env.CONSOLE_URL || 'http://console.localhost',
     trace: 'on-first-retry',
   },
 })

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -1,0 +1,1108 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.2
+        version: 1.61.0
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.31
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.31)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@5.4.21)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.11
+        version: 5.4.21
+
+packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.31':
+    resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.376:
+    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.48:
+    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
+    engines: {node: '>=18'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/estree@1.0.9': {}
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.31)':
+    dependencies:
+      '@types/react': 18.3.31
+
+  '@types/react@18.3.31':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.38: {}
+
+  browserslist@4.28.4:
+    dependencies:
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.376
+      node-releases: 2.0.48
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  caniuse-lite@1.0.30001799: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.376: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  node-releases@2.0.48: {}
+
+  picocolors@1.1.1: {}
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
+    dependencies:
+      browserslist: 4.28.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.62.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useState } from 'react'
+import { api, App as TApp } from './api'
+import { AppDetail } from './AppDetail'
+
+export default function App() {
+  const [appId, setAppId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!error) return
+    const t = setTimeout(() => setError(null), 4500)
+    return () => clearTimeout(t)
+  }, [error])
+
+  return (
+    <>
+      <div className="topbar">
+        <div className="brand" style={{ cursor: 'pointer' }} onClick={() => setAppId(null)}>
+          sandboxd <span className="dot">/</span> console
+        </div>
+        <div className="spacer" />
+        {appId && (
+          <button className="btn btn-ghost btn-sm" onClick={() => setAppId(null)}>
+            ← Apps
+          </button>
+        )}
+      </div>
+      <div className="container">
+        {appId ? (
+          <AppDetail appId={appId} onError={setError} />
+        ) : (
+          <AppList onOpen={setAppId} onError={setError} />
+        )}
+      </div>
+      {error && (
+        <div className="toast" onClick={() => setError(null)} data-testid="toast">
+          {error}
+        </div>
+      )}
+    </>
+  )
+}
+
+function AppList({ onOpen, onError }: { onOpen: (id: string) => void; onError: (m: string) => void }) {
+  const [apps, setApps] = useState<TApp[] | null>(null)
+  const [name, setName] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(() => {
+    api.listApps().then(setApps).catch((e) => onError(e.message))
+  }, [onError])
+  useEffect(load, [load])
+
+  const create = async () => {
+    if (!name.trim()) return
+    setBusy(true)
+    try {
+      const a = await api.createApp({ name: name.trim() })
+      setName('')
+      onOpen(a.id)
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="stack">
+      <h1>Apps</h1>
+      <div className="card">
+        <div className="row">
+          <input
+            className="input"
+            placeholder="New app name…"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && create()}
+            data-testid="app-name"
+          />
+          <button
+            className="btn btn-primary"
+            onClick={create}
+            disabled={busy || !name.trim()}
+            data-testid="create-app"
+          >
+            Create app
+          </button>
+        </div>
+      </div>
+
+      {apps === null ? (
+        <p className="muted">Loading…</p>
+      ) : apps.length === 0 ? (
+        <p className="muted">No apps yet — create one above to get started.</p>
+      ) : (
+        <div className="grid" data-testid="app-list">
+          {apps.map((a) => (
+            <div key={a.id} className="card click" onClick={() => onOpen(a.id)} data-testid="app-card">
+              <div className="card-title">{a.name}</div>
+              <div className="muted mono" style={{ fontSize: 12, marginBottom: 12 }}>
+                {a.description || a.id}
+              </div>
+              <div className="row">
+                <span className={`badge ${a.current_sandbox_id ? 'running' : ''}`}>
+                  <span className="dot-i" />
+                  {a.current_sandbox_id ? 'sandbox' : 'no sandbox'}
+                </span>
+                <div className="spacer" />
+                {a.tags?.slice(0, 3).map((t) => (
+                  <span key={t} className="tag">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/console/src/AppDetail.tsx
+++ b/console/src/AppDetail.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api, App as TApp, Sandbox } from './api'
+import { StatusBadge } from './ui'
+
+export function AppDetail({ appId, onError }: { appId: string; onError: (m: string) => void }) {
+  const [app, setApp] = useState<TApp | null>(null)
+  const [sb, setSb] = useState<Sandbox | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      const a = await api.getApp(appId)
+      setApp(a)
+      setSb(a.current_sandbox_id ? await api.getSandbox(a.current_sandbox_id) : null)
+    } catch (e) {
+      onError((e as Error).message)
+    }
+  }, [appId, onError])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+  useEffect(() => {
+    const t = setInterval(refresh, 4000) // reflect status/preview changes
+    return () => clearInterval(t)
+  }, [refresh])
+
+  const act = async (fn: () => Promise<unknown>) => {
+    setBusy(true)
+    try {
+      await fn()
+      await refresh()
+    } catch (e) {
+      onError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!app) return <p className="muted">Loading…</p>
+
+  const status = sb?.status
+  const previewURL = sb?.preview?.url
+
+  return (
+    <div className="stack">
+      <div className="row">
+        <div>
+          <h1>{app.name}</h1>
+          <div className="muted mono" style={{ fontSize: 12, marginTop: 4 }}>{app.id}</div>
+        </div>
+        <div className="spacer" />
+        {sb && <StatusBadge status={status} />}
+      </div>
+
+      <div className="row" data-testid="controls">
+        {!sb && (
+          <button
+            className="btn btn-primary"
+            disabled={busy}
+            data-testid="create-sandbox"
+            onClick={() => act(() => api.createAppSandbox(appId))}
+          >
+            Create sandbox
+          </button>
+        )}
+        {sb && status === 'stopped' && (
+          <button className="btn btn-primary" disabled={busy} data-testid="start" onClick={() => act(() => api.startSandbox(sb.id))}>
+            Start
+          </button>
+        )}
+        {sb && status === 'running' && (
+          <button className="btn btn-outline" disabled={busy} data-testid="stop" onClick={() => act(() => api.stopSandbox(sb.id))}>
+            Stop
+          </button>
+        )}
+        {sb && (
+          <button
+            className="btn btn-outline"
+            disabled={busy}
+            data-testid="snapshot"
+            title="Snapshots capture a stopped sandbox"
+            onClick={() => act(() => api.createSnapshot(sb.id, `${app.name}-${Date.now()}`))}
+          >
+            Snapshot
+          </button>
+        )}
+        {sb && (
+          <button className="btn btn-ghost" disabled={busy} data-testid="delete-sandbox" onClick={() => act(() => api.deleteSandbox(sb.id))}>
+            Delete sandbox
+          </button>
+        )}
+      </div>
+
+      <div className="detail">
+        <div>
+          <h2>Preview</h2>
+          {previewURL && status === 'running' ? (
+            <iframe className="preview-frame" src={previewURL} title="preview" data-testid="preview" />
+          ) : (
+            <div className="preview-empty">{sb ? 'Sandbox not running' : 'No sandbox yet'}</div>
+          )}
+          {previewURL && (
+            <div className="mono" style={{ fontSize: 12, marginTop: 8 }}>
+              <a href={previewURL} target="_blank" rel="noreferrer" className="linklike">
+                {previewURL} ↗
+              </a>
+            </div>
+          )}
+        </div>
+
+        <TaskPanel sandboxId={sb?.id} running={status === 'running'} onError={onError} />
+      </div>
+    </div>
+  )
+}
+
+function TaskPanel({
+  sandboxId,
+  running,
+  onError,
+}: {
+  sandboxId?: string
+  running: boolean
+  onError: (m: string) => void
+}) {
+  const [prompt, setPrompt] = useState('')
+  const [status, setStatus] = useState<string | null>(null)
+  const [log, setLog] = useState<string[]>([])
+  const esRef = useRef<EventSource | null>(null)
+  const logRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => () => esRef.current?.close(), [])
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [log])
+
+  const run = async () => {
+    if (!sandboxId || !prompt.trim()) return
+    setLog([])
+    setStatus('running')
+    try {
+      const t = await api.submitTask(sandboxId, prompt.trim())
+      esRef.current?.close()
+      const es = new EventSource(api.taskEventsURL(sandboxId, t.id))
+      esRef.current = es
+      for (const type of ['status', 'message', 'tool', 'build']) {
+        es.addEventListener(type, (m) => setLog((l) => [...l, `[${type}] ${(m as MessageEvent).data}`]))
+      }
+      es.addEventListener('done', () => {
+        es.close()
+        api
+          .getTask(sandboxId, t.id)
+          .then((r) => setStatus(r.status + (r.build_ok ? ' · build ok' : '')))
+          .catch(() => setStatus('done'))
+      })
+      es.onerror = () => es.close()
+    } catch (e) {
+      onError((e as Error).message)
+      setStatus(null)
+    }
+  }
+
+  return (
+    <div className="card">
+      <h2>Task</h2>
+      <textarea
+        className="textarea"
+        placeholder="Describe a change — e.g. “add a dark-mode toggle”"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        data-testid="task-prompt"
+      />
+      <div className="row" style={{ marginTop: 10 }}>
+        <button className="btn btn-primary" disabled={!running || !prompt.trim()} onClick={run} data-testid="run-task">
+          Run task
+        </button>
+        <div className="spacer" />
+        {status && (
+          <span className="badge" data-testid="task-status">
+            {status}
+          </span>
+        )}
+      </div>
+      {!running && <div className="muted" style={{ fontSize: 12, marginTop: 8 }}>Start the sandbox to run a task.</div>}
+      {log.length > 0 && (
+        <div className="log mono" ref={logRef} data-testid="task-log" style={{ marginTop: 12 }}>
+          {log.map((l, i) => (
+            <div key={i} className="ev">
+              {l}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -1,0 +1,77 @@
+// Thin client for the public sandboxd /v1 API. The console talks ONLY
+// to /v1 (same-origin; proxied to sandboxd by vite in dev and nginx in
+// the container). No Go imports, no DB, no workspace access.
+
+export interface App {
+  id: string
+  name: string
+  description: string
+  tags: string[]
+  current_sandbox_id?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Preview {
+  url: string
+  status: string
+}
+
+export interface Sandbox {
+  id: string
+  status: string
+  preview?: Preview
+}
+
+export interface TaskResult {
+  id: string
+  status: string
+  build_ok?: boolean
+  files_changed?: string[]
+  error_message?: string
+  preview_status_after?: string
+}
+
+async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method,
+    headers: body !== undefined ? { 'content-type': 'application/json' } : undefined,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`
+    try {
+      const e = await res.json()
+      if (e?.error?.message) message = e.error.message
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(message)
+  }
+  const ct = res.headers.get('content-type') || ''
+  return (ct.includes('application/json') ? res.json() : (res.text() as unknown)) as Promise<T>
+}
+
+export const api = {
+  listApps: () => req<{ apps: App[] }>('GET', '/v1/apps').then((r) => r.apps || []),
+  createApp: (b: { name: string; description?: string; tags?: string[] }) =>
+    req<App>('POST', '/v1/apps', b),
+  getApp: (id: string) => req<App>('GET', `/v1/apps/${id}`),
+  createAppSandbox: (id: string, body: { template?: string } = {}) =>
+    req<Sandbox>('POST', `/v1/apps/${id}/sandbox`, body),
+
+  getSandbox: (id: string) => req<Sandbox>('GET', `/v1/sandboxes/${id}`),
+  startSandbox: (id: string) => req<Sandbox>('POST', `/v1/sandboxes/${id}/start`),
+  stopSandbox: (id: string) => req<Sandbox>('POST', `/v1/sandboxes/${id}/stop`),
+  deleteSandbox: (id: string) => req<unknown>('DELETE', `/v1/sandboxes/${id}`),
+
+  submitTask: (id: string, prompt: string) =>
+    req<{ id: string }>('POST', `/v1/sandboxes/${id}/tasks`, { prompt, agent: 'opencode' }),
+  getTask: (id: string, taskId: string) =>
+    req<TaskResult>('GET', `/v1/sandboxes/${id}/tasks/${taskId}`),
+  taskEventsURL: (id: string, taskId: string) =>
+    `/v1/sandboxes/${id}/tasks/${taskId}/events`,
+
+  createSnapshot: (sandboxId: string, name: string) =>
+    req<{ id: string }>('POST', '/v1/snapshots', { source_sandbox_id: sandboxId, name }),
+}

--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './styles.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/console/src/styles.css
+++ b/console/src/styles.css
@@ -1,0 +1,306 @@
+/* shadcn / Vercel-flavoured design tokens (zinc dark). Hand-rolled to
+   keep the MVP dependency-light; same visual language as shadcn/ui. */
+:root {
+  --background: #09090b;
+  --card: #0c0c0f;
+  --muted: #18181b;
+  --border: #27272a;
+  --input: #27272a;
+  --foreground: #fafafa;
+  --muted-foreground: #a1a1aa;
+  --primary: #fafafa;
+  --primary-foreground: #09090b;
+  --ring: #52525b;
+  --green: #22c55e;
+  --red: #ef4444;
+  --amber: #f59e0b;
+  --radius: 8px;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  height: 100%;
+}
+body {
+  margin: 0;
+  background: var(--background);
+  color: var(--foreground);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Inter, Roboto,
+    sans-serif;
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+code,
+.mono {
+  font-family: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+}
+
+/* layout */
+.topbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  background: color-mix(in srgb, var(--background) 80%, transparent);
+  backdrop-filter: blur(8px);
+  z-index: 10;
+}
+.brand {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.brand .dot {
+  color: var(--muted-foreground);
+}
+.container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 28px 20px 64px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.spacer {
+  flex: 1;
+}
+.muted {
+  color: var(--muted-foreground);
+}
+h1 {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+h2 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 12px;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 14px;
+  margin-top: 20px;
+}
+
+/* card */
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+}
+.card.click {
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.card.click:hover {
+  border-color: var(--ring);
+  background: var(--muted);
+}
+.card-title {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: 4px;
+}
+
+/* button */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+}
+.btn-primary:hover:not(:disabled) {
+  opacity: 0.9;
+}
+.btn-outline {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--foreground);
+}
+.btn-outline:hover:not(:disabled) {
+  background: var(--muted);
+}
+.btn-ghost {
+  background: transparent;
+  color: var(--muted-foreground);
+}
+.btn-ghost:hover:not(:disabled) {
+  background: var(--muted);
+  color: var(--foreground);
+}
+.btn-sm {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+/* input */
+.input,
+.textarea {
+  width: 100%;
+  background: transparent;
+  border: 1px solid var(--input);
+  border-radius: 6px;
+  color: var(--foreground);
+  font: inherit;
+  padding: 8px 10px;
+  outline: none;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.input:focus,
+.textarea:focus {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 30%, transparent);
+}
+.textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+
+/* badge */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  padding: 0 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.badge .dot-i {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--muted-foreground);
+}
+.badge.running .dot-i {
+  background: var(--green);
+}
+.badge.running {
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 40%, var(--border));
+}
+.badge.stopped .dot-i {
+  background: var(--amber);
+}
+.badge.error .dot-i {
+  background: var(--red);
+}
+.badge.error {
+  color: var(--red);
+}
+
+.tag {
+  display: inline-block;
+  font-size: 12px;
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 6px;
+}
+
+/* detail layout */
+.detail {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 16px;
+  align-items: start;
+  margin-top: 20px;
+}
+@media (max-width: 900px) {
+  .detail {
+    grid-template-columns: 1fr;
+  }
+}
+.preview-frame {
+  width: 100%;
+  height: 460px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: #000;
+}
+.preview-empty {
+  height: 460px;
+  display: grid;
+  place-items: center;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  color: var(--muted-foreground);
+}
+.log {
+  background: #000;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px;
+  height: 220px;
+  overflow: auto;
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.log .ev {
+  color: var(--muted-foreground);
+}
+.toast {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--card);
+  border: 1px solid var(--red);
+  color: var(--foreground);
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  z-index: 50;
+}
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.linklike {
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+.linklike:hover {
+  color: var(--foreground);
+}

--- a/console/src/ui.tsx
+++ b/console/src/ui.tsx
@@ -1,0 +1,10 @@
+export function StatusBadge({ status }: { status?: string }) {
+  const s = status || 'unknown'
+  const cls = s === 'running' ? 'running' : s === 'stopped' ? 'stopped' : s === 'error' ? 'error' : ''
+  return (
+    <span className={`badge ${cls}`} data-testid="status">
+      <span className="dot-i" />
+      {s}
+    </span>
+  )
+}

--- a/console/tsconfig.json
+++ b/console/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// In dev, proxy the public API to a local sandboxd so the SPA can use
+// same-origin relative `/v1` paths (no CORS, no auth in the single-user
+// default). Override the target with SANDBOXD_URL. In the container the
+// same `/v1` paths are proxied by nginx (see nginx.conf).
+const target = process.env.SANDBOXD_URL || 'http://127.0.0.1:9090'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 8787,
+    proxy: {
+      '/v1': { target, changeOrigin: true },
+    },
+  },
+})

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -131,6 +131,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /v1/sandboxes", s.observe("POST /v1/sandboxes", s.v1CreateSandbox))
 	mux.HandleFunc("GET /v1/sandboxes/{id}", s.observe("GET /v1/sandboxes/{id}", s.v1GetSandbox))
 	mux.HandleFunc("POST /v1/sandboxes/{id}/stop", s.observe("POST /v1/sandboxes/{id}/stop", s.v1StopSandbox))
+	mux.HandleFunc("POST /v1/sandboxes/{id}/start", s.observe("POST /v1/sandboxes/{id}/start", s.v1StartSandbox))
 	mux.HandleFunc("DELETE /v1/sandboxes/{id}", s.observe("DELETE /v1/sandboxes/{id}", s.v1DeleteSandbox))
 	mux.HandleFunc("POST /v1/sandboxes/{id}/tasks", s.observe("POST /v1/sandboxes/{id}/tasks", s.v1SubmitTask))
 	mux.HandleFunc("GET /v1/sandboxes/{id}/tasks/{taskId}", s.observe("GET /v1/sandboxes/{id}/tasks/{taskId}", s.v1GetTask))

--- a/control-plane/internal/api/openapi_contract_test.go
+++ b/control-plane/internal/api/openapi_contract_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestOpenAPIContractMatchesRoutes is the console<->sandboxd contract
+// guard: every public /v1 route registered in api.go must be documented
+// in docs/openapi.yaml, and vice versa. The console (and any external
+// integration) binds to that spec, so drift in either direction is a
+// breaking-change waiting to happen.
+func TestOpenAPIContractMatchesRoutes(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	dir := filepath.Dir(thisFile)
+	specPath := filepath.Join(dir, "..", "..", "..", "docs", "openapi.yaml")
+	apiPath := filepath.Join(dir, "api.go")
+
+	routes := v1RoutesFromSource(t, apiPath)
+	spec := v1OpsFromSpec(t, specPath)
+
+	if missing := diff(routes, spec); len(missing) > 0 {
+		t.Errorf("routes NOT documented in docs/openapi.yaml:\n  %s", strings.Join(missing, "\n  "))
+	}
+	if extra := diff(spec, routes); len(extra) > 0 {
+		t.Errorf("docs/openapi.yaml documents endpoints with no matching route:\n  %s", strings.Join(extra, "\n  "))
+	}
+}
+
+// v1RoutesFromSource extracts `"METHOD /v1/..."` patterns registered in api.go.
+func v1RoutesFromSource(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	re := regexp.MustCompile(`"(GET|POST|PUT|PATCH|DELETE) (/v1/[^"]+)"`)
+	out := map[string]bool{}
+	for _, m := range re.FindAllStringSubmatch(string(b), -1) {
+		out[m[1]+" "+m[2]] = true
+	}
+	if len(out) == 0 {
+		t.Fatal("no /v1 routes found in api.go")
+	}
+	return out
+}
+
+// v1OpsFromSpec extracts METHOD+path operations under /v1 from the
+// OpenAPI YAML using a small indentation-aware scan (no yaml dep).
+func v1OpsFromSpec(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	pathRe := regexp.MustCompile(`^  (/v1/\S+):\s*$`)
+	methodRe := regexp.MustCompile(`^    (get|post|put|patch|delete):\s*$`)
+	out := map[string]bool{}
+	cur := ""
+	for _, line := range strings.Split(string(b), "\n") {
+		if m := pathRe.FindStringSubmatch(line); m != nil {
+			cur = m[1]
+			continue
+		}
+		// any 2-space top-level key ends the current path block
+		if strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") && strings.TrimSpace(line) != "" {
+			if pathRe.FindStringSubmatch(line) == nil {
+				cur = ""
+			}
+		}
+		if m := methodRe.FindStringSubmatch(line); m != nil && cur != "" {
+			out[strings.ToUpper(m[1])+" "+cur] = true
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no /v1 operations found in openapi.yaml")
+	}
+	return out
+}
+
+func diff(a, b map[string]bool) []string {
+	var out []string
+	for k := range a {
+		if !b[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/control-plane/internal/api/v1.go
+++ b/control-plane/internal/api/v1.go
@@ -102,7 +102,14 @@ func (s *Server) delegate(r *http.Request, h http.HandlerFunc, method, path stri
 }
 
 func (s *Server) previewURL(id string) string {
-	return fmt.Sprintf("https://s-%s-3000.preview.%s", id, s.PreviewDomain)
+	// Reflect the actual scheme: previews are served over plain HTTP
+	// unless PreviewTLS is configured (so a local/default deploy returns
+	// a reachable http:// URL the console can iframe).
+	scheme := "http"
+	if s.PreviewTLS {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://s-%s-3000.preview.%s", scheme, id, s.PreviewDomain)
 }
 
 // v1SandboxFromRow reshapes a stored sandbox to the v1 object, folding
@@ -292,6 +299,43 @@ func (s *Server) v1StopSandbox(w http.ResponseWriter, r *http.Request) {
 	}
 	s.auditAction(r, audit.Entry{Action: "sandbox.stop", Target: id})
 	sb, _ = s.Store.Get(r.Context(), id)
+	writeJSON(w, http.StatusOK, s.v1SandboxFromRow(r, sb))
+}
+
+// --- POST /v1/sandboxes/{id}/start ----------------------------------
+
+// v1StartSandbox wakes a stopped sandbox. It is the public counterpart
+// of /stop, so a console (API-only) need not reach the internal wake
+// path. Idempotent when already running.
+func (s *Server) v1StartSandbox(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sb, err := s.Store.Get(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such sandbox")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if sb.Status == "running" {
+		writeJSON(w, http.StatusOK, s.v1SandboxFromRow(r, sb)) // idempotent
+		return
+	}
+	if sb.Status != "stopped" {
+		writeV1Err(w, http.StatusConflict, "conflict", "sandbox is "+sb.Status+" — cannot start")
+		return
+	}
+	code, body := s.delegate(r, s.handleWakeJSON, http.MethodPost, "/wake/"+id,
+		map[string]string{"id": id}, nil)
+	if code != http.StatusOK {
+		relayV1Error(w, code, body) // 503 -> sandbox_capacity, etc.
+		return
+	}
+	if sb, err = s.Store.Get(r.Context(), id); err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
 	writeJSON(w, http.StatusOK, s.v1SandboxFromRow(r, sb))
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,6 +90,12 @@ services:
   # Optional web console:  docker compose --profile console up
   # Builds the Vite SPA and serves it from nginx, proxying the public /v1
   # API to sandboxd. API-only — it never touches the DB or workspaces.
+  #
+  # Routed through the SAME Traefik as the previews, by Host header:
+  #   console.<PREVIEW_DOMAIN>  -> this console
+  #   *.preview.<PREVIEW_DOMAIN> -> sandbox previews
+  # one entrypoint (:${HTTP_PORT}), Traefik picks by the router rule.
+  # Reachable at http://console.${PREVIEW_DOMAIN:-localhost}:${HTTP_PORT}.
   console:
     profiles: [console]
     build:
@@ -98,7 +104,12 @@ services:
     restart: unless-stopped
     depends_on:
       - sandboxd
-    ports:
-      - "${CONSOLE_BIND:-127.0.0.1:8787}:80"
+      - traefik
+    labels:
+      - "sandboxd.managed=true" # satisfies the traefik docker-provider constraint
+      - "traefik.enable=true"
+      - "traefik.http.routers.console.rule=Host(`console.${PREVIEW_DOMAIN:-localhost}`)"
+      - "traefik.http.routers.console.entrypoints=web"
+      - "traefik.http.services.console.loadbalancer.server.port=80"
     networks:
       - sandboxd_net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,3 +86,19 @@ services:
       SANDBOXD_IDLE_THRESHOLD_SECONDS: ${SANDBOXD_IDLE_THRESHOLD_SECONDS:-2100}
     networks:
       - sandboxd_net
+
+  # Optional web console:  docker compose --profile console up
+  # Builds the Vite SPA and serves it from nginx, proxying the public /v1
+  # API to sandboxd. API-only — it never touches the DB or workspaces.
+  console:
+    profiles: [console]
+    build:
+      context: ./console
+    image: sandboxd-console:0.1.0
+    restart: unless-stopped
+    depends_on:
+      - sandboxd
+    ports:
+      - "${CONSOLE_BIND:-127.0.0.1:8787}:80"
+    networks:
+      - sandboxd_net

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,488 @@
+openapi: 3.0.3
+info:
+  title: sandboxd /v1 API
+  version: "0.2.0"
+  description: >
+    The public, tenant-scoped API for sandboxd. This is the only surface a
+    console or external integration should use — the internal /sandbox and
+    /wake endpoints are not part of this contract. Scoped by the API token
+    (Bearer); when auth is disabled (the single-user default) the whole
+    surface is reachable without a token.
+servers:
+  - url: http://127.0.0.1:9090
+    description: Default loopback bind (docker-compose maps SANDBOXD_API_BIND here)
+security:
+  - bearerAuth: []
+  - {} # auth disabled by default (single-user)
+
+tags:
+  - name: apps
+  - name: sandboxes
+  - name: tasks
+  - name: snapshots
+
+paths:
+  /v1/apps:
+    get:
+      tags: [apps]
+      summary: List apps (tenant-scoped)
+      parameters:
+        - in: query
+          name: external_user_id
+          schema: { type: string }
+          description: Optional integration-tag filter.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  apps:
+                    type: array
+                    items: { $ref: "#/components/schemas/App" }
+    post:
+      tags: [apps]
+      summary: Create an app
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateAppRequest" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/App" }
+        "400": { $ref: "#/components/responses/Error" }
+
+  /v1/apps/{id}:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+    get:
+      tags: [apps]
+      summary: Get an app
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/App" }
+        "404": { $ref: "#/components/responses/Error" }
+    patch:
+      tags: [apps]
+      summary: Update an app (partial)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/PatchAppRequest" }
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/App" }
+        "404": { $ref: "#/components/responses/Error" }
+
+  /v1/apps/{id}/sandbox:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+    post:
+      tags: [apps]
+      summary: Create the app's current sandbox (one live sandbox per app)
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                template: { type: string, description: "Template name; omit for react-standard, 'blank' for empty." }
+                ports: { type: array, items: { type: integer }, default: [3000] }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Sandbox" }
+        "404": { $ref: "#/components/responses/Error" }
+        "409":
+          description: The app already has a live sandbox.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/sandboxes:
+    post:
+      tags: [sandboxes]
+      summary: Create a sandbox (programmatic; apps usually use /v1/apps/{id}/sandbox)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateSandboxRequest" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Sandbox" }
+        "400": { $ref: "#/components/responses/Error" }
+
+  /v1/sandboxes/{id}:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+    get:
+      tags: [sandboxes]
+      summary: Get a sandbox (status + live preview state)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Sandbox" }
+        "404": { $ref: "#/components/responses/Error" }
+    delete:
+      tags: [sandboxes]
+      summary: Destroy the sandbox (container + workspace)
+      responses:
+        "200": { description: Destroyed }
+        "404": { $ref: "#/components/responses/Error" }
+
+  /v1/sandboxes/{id}/start:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    post:
+      tags: [sandboxes]
+      summary: Start (wake) a stopped sandbox. Idempotent when running.
+      responses:
+        "200":
+          description: Running
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Sandbox" }
+        "409": { $ref: "#/components/responses/Error" }
+        "503":
+          description: Capacity pushback (Retry-After).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/sandboxes/{id}/stop:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    post:
+      tags: [sandboxes]
+      summary: Stop a running sandbox (frees RAM; wakes on start). Idempotent when stopped.
+      responses:
+        "200":
+          description: Stopped
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Sandbox" }
+        "409":
+          description: A task is in progress; cancel it first.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/sandboxes/{id}/tasks:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    post:
+      tags: [tasks]
+      summary: Submit a coding-agent task (wakes a stopped sandbox first)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SubmitTaskRequest" }
+      responses:
+        "202":
+          description: Accepted (task running)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  sandbox_id: { type: string }
+                  status: { type: string, example: running }
+                  agent: { type: string }
+                  events_url: { type: string }
+        "400": { $ref: "#/components/responses/Error" }
+        "409":
+          description: A task is already in progress.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/sandboxes/{id}/tasks/{taskId}:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+      - in: path
+        name: taskId
+        required: true
+        schema: { type: string }
+    get:
+      tags: [tasks]
+      summary: Get a task's canonical result
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskResult" }
+        "404": { $ref: "#/components/responses/Error" }
+
+  /v1/sandboxes/{id}/tasks/{taskId}/events:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+      - in: path
+        name: taskId
+        required: true
+        schema: { type: string }
+    get:
+      tags: [tasks]
+      summary: Live task event stream (Server-Sent Events)
+      description: >
+        text/event-stream of status/message/tool/build/done events. The
+        console consumes this with EventSource for live status + logs.
+      responses:
+        "200":
+          description: SSE stream
+          content:
+            text/event-stream:
+              schema: { type: string }
+
+  /v1/sandboxes/{id}/tasks/{taskId}/cancel:
+    parameters:
+      - $ref: "#/components/parameters/Id"
+      - in: path
+        name: taskId
+        required: true
+        schema: { type: string }
+    post:
+      tags: [tasks]
+      summary: Cancel a running task
+      responses:
+        "200": { description: Cancelled }
+
+  /v1/sandboxes/{id}/files:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    get:
+      tags: [sandboxes]
+      summary: List workspace files
+      responses:
+        "200": { description: OK }
+    put:
+      tags: [sandboxes]
+      summary: Write a workspace file
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path, content]
+              properties:
+                path: { type: string }
+                content: { type: string }
+                append: { type: boolean }
+      responses:
+        "200": { description: Written }
+
+  /v1/sandboxes/{id}/files/content:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    get:
+      tags: [sandboxes]
+      summary: Read a workspace file
+      parameters:
+        - in: query
+          name: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: OK }
+
+  /v1/sandboxes/{id}/export:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    get:
+      tags: [sandboxes]
+      summary: Export the workspace as a zip
+      responses:
+        "200":
+          description: zip archive
+          content:
+            application/zip:
+              schema: { type: string, format: binary }
+
+  /v1/snapshots:
+    get:
+      tags: [snapshots]
+      summary: List snapshots (tenant-scoped)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  snapshots:
+                    type: array
+                    items: { $ref: "#/components/schemas/Snapshot" }
+    post:
+      tags: [snapshots]
+      summary: Capture a snapshot of a stopped sandbox
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [source_sandbox_id, name]
+              properties:
+                source_sandbox_id: { type: string }
+                name: { type: string }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Snapshot" }
+        "409":
+          description: Source sandbox is running; stop it first.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /v1/snapshots/{id}:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    get:
+      tags: [snapshots]
+      summary: Get a snapshot
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Snapshot" }
+        "404": { $ref: "#/components/responses/Error" }
+    delete:
+      tags: [snapshots]
+      summary: Delete a snapshot
+      responses:
+        "204": { description: Deleted }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    Id:
+      in: path
+      name: id
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Error
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code: { type: string }
+            message: { type: string }
+            retryable: { type: boolean }
+    App:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        description: { type: string }
+        tags: { type: array, items: { type: string } }
+        external_user_id: { type: string }
+        external_project_id: { type: string }
+        current_sandbox_id: { type: string, description: "Empty when the app has no live sandbox." }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    CreateAppRequest:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        description: { type: string }
+        tags: { type: array, items: { type: string } }
+        external_user_id: { type: string }
+        external_project_id: { type: string }
+    PatchAppRequest:
+      type: object
+      properties:
+        name: { type: string }
+        description: { type: string }
+        tags: { type: array, items: { type: string } }
+    Sandbox:
+      type: object
+      properties:
+        id: { type: string }
+        status: { type: string, enum: [creating, running, stopped, error] }
+        template: { type: string }
+        preview: { $ref: "#/components/schemas/Preview" }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    Preview:
+      type: object
+      properties:
+        url: { type: string }
+        status: { type: string, enum: [starting, up, down, error] }
+        last_checked_at: { type: string, format: date-time }
+    CreateSandboxRequest:
+      type: object
+      properties:
+        template: { type: string }
+        from_snapshot: { type: string }
+        visibility: { type: string, enum: [public, private] }
+        project:
+          type: object
+          properties:
+            id: { type: string }
+            user_id: { type: string }
+    SubmitTaskRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt: { type: string }
+        agent: { type: string, enum: [opencode], default: opencode }
+        timeout_s: { type: integer, description: "0/omitted = 10m default; max 86400." }
+    TaskResult:
+      type: object
+      properties:
+        id: { type: string }
+        sandbox_id: { type: string }
+        status: { type: string, enum: [running, succeeded, failed, cancelled] }
+        failure_reason: { type: string }
+        error_message: { type: string }
+        files_changed: { type: array, items: { type: string } }
+        build_ok: { type: boolean }
+        build_error_message: { type: string }
+        preview_status_after: { type: string }
+        duration_ms: { type: integer }
+    Snapshot:
+      type: object
+      properties:
+        id: { type: string }
+        name: { type: string }
+        status: { type: string }
+        source_sandbox_id: { type: string }
+        base_image: { type: string }
+        visibility: { type: string }
+        size_bytes: { type: integer }
+        created_at: { type: string, format: date-time }


### PR DESCRIPTION
Adds an **optional web console** for managing apps on top of sandboxd, plus a versioned **`/v1` OpenAPI spec**. The console lives in `console/` and talks **only** to the public `/v1` API — no Go imports, no database, no workspace access — so it can later move to its own repo cleanly.

## What's included
- **`docs/openapi.yaml`** — the public `/v1` API as OpenAPI 3.0 (apps, sandboxes, tasks/SSE, snapshots).
- **`console/`** — a Vite + React SPA: app list, app detail with a live preview iframe, task submit with live SSE logs, and start/stop/snapshot/delete. Playwright specs for the main flow.
- **`POST /v1/sandboxes/{id}/start`** — a public counterpart to `/stop`, so an API-only client can wake a stopped sandbox without the internal wake endpoint.
- **Preview URLs now reflect `PreviewTLS`** (http on a default local deploy) so the preview iframe loads without TLS.
- **Packaging:** `docker compose --profile console up` builds the SPA and serves it from nginx, routed through the same Traefik as the previews by Host header (`console.<domain>` → console, `*.preview.<domain>` → sandboxes). Running without the profile is unchanged.
- **CI:** a `console` job builds the SPA + image so a TypeScript/build break is caught.

## Scope
Single-user, auth-off, public previews — the simplest thing that's useful. Multi-user auth and private-preview embedding can come later.

## Verified
Go, the SPA, and the console image all build; `nginx -t` valid; `compose --profile console` resolves; `go vet` / `go test` green. CI: `go`, `e2e`, and `console` all pass.

Open `http://console.localhost` after `docker compose --profile console up`.
