### PR TITLE
feat(config): app-scoped config & secrets, encrypted at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,12 @@ SANDBOXD_API_BIND=127.0.0.1:9090
 SANDBOXD_API_AUTH_DISABLED=true
 SANDBOXD_API_TOKENS=
 
+# Master key for encrypting sensitive app config/secrets at rest
+# (base64 of 32 bytes). Leave empty to auto-generate a 0600 keyfile at
+# <data dir>/secrets.key. Back this up — losing it makes secrets
+# unrecoverable; treat it as sensitive as the secrets themselves.
+SANDBOXD_SECRETS_KEY=
+
 # ── Resource policy (advanced) ───────────────────────────────────────
 # Write cgroup v2 memory.high after start (soft throttle). Needs host
 # cgroup access the control-plane container usually lacks, so it is OFF

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -43,6 +43,7 @@ import (
 	nginxwatch "github.com/sandboxd/control-plane/internal/nginx"
 	"github.com/sandboxd/control-plane/internal/reaper"
 	"github.com/sandboxd/control-plane/internal/reconcile"
+	"github.com/sandboxd/control-plane/internal/secrets"
 	"github.com/sandboxd/control-plane/internal/snapshot"
 	"github.com/sandboxd/control-plane/internal/store"
 	"github.com/sandboxd/control-plane/internal/wake"
@@ -322,8 +323,17 @@ func main() {
 	wakeHandler.ForwardAuthDenyMode = denyMode
 	wakeHandler.SetMemoryHigh = setMemoryHigh
 
+	// app_config/secrets encryption: SANDBOXD_SECRETS_KEY (base64 32
+	// bytes) or an auto-generated 0600 keyfile under the data dir.
+	secretsCipher, err := secrets.Load(os.Getenv("SANDBOXD_SECRETS_KEY"), filepath.Join(dataDir, "secrets.key"))
+	if err != nil {
+		log.Error("init secrets encryption", "err", err.Error())
+		os.Exit(1)
+	}
+
 	server := &api.Server{
 		Store:               st,
+		Secrets:             secretsCipher,
 		Docker:              dockerClient,
 		Loopback:            loopMgr,
 		Log:                 log.With("component", "api"),

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sandboxd/control-plane/internal/idlock"
 	"github.com/sandboxd/control-plane/internal/loopback"
 	"github.com/sandboxd/control-plane/internal/metrics"
+	"github.com/sandboxd/control-plane/internal/secrets"
 	"github.com/sandboxd/control-plane/internal/snapshot"
 	"github.com/sandboxd/control-plane/internal/store"
 	"github.com/sandboxd/control-plane/internal/wake"
@@ -72,6 +73,11 @@ type Server struct {
 	// LLMTxtPath is the host file served at the public, tokenless
 	// GET /llm.txt (the API contract for integrators). Empty → 404.
 	LLMTxtPath string
+
+	// Secrets encrypts sensitive app_config values at rest (Slice 1 of
+	// app config/secrets). nil-safe: sensitive config writes return 503
+	// when unset, but main.go always configures it.
+	Secrets *secrets.Cipher
 
 	// Phase 5 additions — nil-safe so existing tests that build a
 	// Server without these still work.
@@ -147,6 +153,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v1/apps/{id}", s.observe("GET /v1/apps/{id}", s.v1GetApp))
 	mux.HandleFunc("PATCH /v1/apps/{id}", s.observe("PATCH /v1/apps/{id}", s.v1PatchApp))
 	mux.HandleFunc("POST /v1/apps/{id}/sandbox", s.observe("POST /v1/apps/{id}/sandbox", s.v1CreateAppSandbox))
+	mux.HandleFunc("POST /v1/apps/{id}/config", s.observe("POST /v1/apps/{id}/config", s.v1CreateAppConfig))
+	mux.HandleFunc("GET /v1/apps/{id}/config", s.observe("GET /v1/apps/{id}/config", s.v1ListAppConfig))
+	mux.HandleFunc("PATCH /v1/apps/{id}/config/{key}", s.observe("PATCH /v1/apps/{id}/config/{key}", s.v1PatchAppConfig))
+	mux.HandleFunc("DELETE /v1/apps/{id}/config/{key}", s.observe("DELETE /v1/apps/{id}/config/{key}", s.v1DeleteAppConfig))
 
 	// Snapshots-as-templates (ops/design/snapshots-as-templates.md).
 	mux.HandleFunc("POST /v1/snapshots", s.observe("POST /v1/snapshots", s.v1CreateSnapshot))

--- a/control-plane/internal/api/v1_app_config.go
+++ b/control-plane/internal/api/v1_app_config.go
@@ -1,0 +1,270 @@
+// v1_app_config.go — app-scoped config and secrets, owned by the
+// control plane (not Docker env, workspace files, or task logs).
+// Sensitive values are AES-256-GCM-encrypted at rest and write-only over
+// the API (GET returns metadata only). Scoped to the app, which is
+// scoped to the API tenant. Plaintext is never logged or audited.
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sandboxd/control-plane/internal/audit"
+	"github.com/sandboxd/control-plane/internal/store"
+)
+
+var validAccessPolicies = map[string]bool{
+	"control_plane_only": true, // never leaves sandboxd (default)
+	"agent_access":       true, // agent task may request via the broker
+	"runtime_access":     true, // app runtime may request via the broker
+	"both":               true,
+}
+
+type v1ConfigItem struct {
+	Key          string  `json:"key"`
+	Sensitive    bool    `json:"sensitive"`
+	AccessPolicy string  `json:"access_policy"`
+	ValueSet     bool    `json:"value_set"`
+	Value        *string `json:"value,omitempty"` // non-sensitive only
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+// redactConfig builds the API view. A sensitive value is never returned.
+func redactConfig(c *store.AppConfig) v1ConfigItem {
+	item := v1ConfigItem{
+		Key:          c.Key,
+		Sensitive:    c.Sensitive,
+		AccessPolicy: c.AccessPolicy,
+		CreatedAt:    c.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:    c.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if c.Sensitive {
+		item.ValueSet = len(c.ValueCiphertext) > 0
+	} else if c.ValuePlaintext.Valid {
+		item.ValueSet = true
+		v := c.ValuePlaintext.String
+		item.Value = &v
+	}
+	return item
+}
+
+// appForConfig resolves the tenant-owned app or writes the error. A
+// missing or cross-tenant app is a 404 (no existence leak).
+func (s *Server) appForConfig(w http.ResponseWriter, r *http.Request) (*store.App, bool) {
+	app, err := s.Store.GetAppForOwner(r.Context(), r.PathValue("id"), tenantToken(r))
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such app")
+		return nil, false
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return nil, false
+	}
+	return app, true
+}
+
+func validConfigKey(k string) bool {
+	if k == "" || len(k) > 256 {
+		return false
+	}
+	return strings.IndexFunc(k, func(r rune) bool { return r < 0x20 || r == 0x7f }) < 0
+}
+
+type v1CreateConfigReq struct {
+	Key          string `json:"key"`
+	Value        string `json:"value"`
+	Sensitive    bool   `json:"sensitive"`
+	AccessPolicy string `json:"access_policy"`
+}
+
+// v1CreateAppConfig — POST /v1/apps/{id}/config.
+func (s *Server) v1CreateAppConfig(w http.ResponseWriter, r *http.Request) {
+	app, ok := s.appForConfig(w, r)
+	if !ok {
+		return
+	}
+	var req v1CreateConfigReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid json: "+err.Error())
+		return
+	}
+	if !validConfigKey(req.Key) {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "key is required (<=256 chars, no control characters)")
+		return
+	}
+	if req.AccessPolicy == "" {
+		req.AccessPolicy = "control_plane_only"
+	}
+	if !validAccessPolicies[req.AccessPolicy] {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid access_policy")
+		return
+	}
+
+	c := &store.AppConfig{ID: newULID(), AppID: app.ID, Key: req.Key,
+		Sensitive: req.Sensitive, AccessPolicy: req.AccessPolicy}
+	if err := s.encodeConfigValue(c, req.Value); err != nil {
+		writeV1Err(w, http.StatusServiceUnavailable, "internal", err.Error())
+		return
+	}
+	if err := s.Store.CreateAppConfig(r.Context(), c); err != nil {
+		if errors.Is(err, store.ErrConflict) {
+			writeV1Err(w, http.StatusConflict, "conflict", "config key already exists; PATCH to update")
+			return
+		}
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	s.auditConfig(r, "app_config.create", app.ID, c.Key)
+	writeJSON(w, http.StatusCreated, redactConfig(c))
+}
+
+// v1ListAppConfig — GET /v1/apps/{id}/config (metadata; redacted).
+func (s *Server) v1ListAppConfig(w http.ResponseWriter, r *http.Request) {
+	app, ok := s.appForConfig(w, r)
+	if !ok {
+		return
+	}
+	rows, err := s.Store.ListAppConfig(r.Context(), app.ID)
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	out := make([]v1ConfigItem, 0, len(rows))
+	for _, c := range rows {
+		out = append(out, redactConfig(c))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"config": out})
+}
+
+type v1PatchConfigReq struct {
+	Value        *string `json:"value"`
+	Sensitive    *bool   `json:"sensitive"`
+	AccessPolicy *string `json:"access_policy"`
+}
+
+// v1PatchAppConfig — PATCH /v1/apps/{id}/config/{key}.
+func (s *Server) v1PatchAppConfig(w http.ResponseWriter, r *http.Request) {
+	app, ok := s.appForConfig(w, r)
+	if !ok {
+		return
+	}
+	key := r.PathValue("key")
+	existing, err := s.Store.GetAppConfig(r.Context(), app.ID, key)
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such config key")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	var req v1PatchConfigReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid json: "+err.Error())
+		return
+	}
+
+	updated := *existing
+	if req.AccessPolicy != nil {
+		if !validAccessPolicies[*req.AccessPolicy] {
+			writeV1Err(w, http.StatusBadRequest, "invalid_request", "invalid access_policy")
+			return
+		}
+		updated.AccessPolicy = *req.AccessPolicy
+	}
+	if req.Sensitive != nil {
+		updated.Sensitive = *req.Sensitive
+	}
+	// Re-encode the stored value only when the value or its sensitivity
+	// changes. A policy-only change keeps the existing bytes untouched.
+	if req.Value != nil || updated.Sensitive != existing.Sensitive {
+		plaintext, err := s.effectiveConfigValue(existing, req.Value)
+		if err != nil {
+			writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+			return
+		}
+		if err := s.encodeConfigValue(&updated, plaintext); err != nil {
+			writeV1Err(w, http.StatusServiceUnavailable, "internal", err.Error())
+			return
+		}
+	}
+	if err := s.Store.UpdateAppConfig(r.Context(), app.ID, key, &updated); err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	got, _ := s.Store.GetAppConfig(r.Context(), app.ID, key)
+	s.auditConfig(r, "app_config.update", app.ID, key)
+	writeJSON(w, http.StatusOK, redactConfig(got))
+}
+
+// v1DeleteAppConfig — DELETE /v1/apps/{id}/config/{key}.
+func (s *Server) v1DeleteAppConfig(w http.ResponseWriter, r *http.Request) {
+	app, ok := s.appForConfig(w, r)
+	if !ok {
+		return
+	}
+	key := r.PathValue("key")
+	if err := s.Store.DeleteAppConfig(r.Context(), app.ID, key); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeV1Err(w, http.StatusNotFound, "not_found", "no such config key")
+			return
+		}
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	s.auditConfig(r, "app_config.delete", app.ID, key)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// encodeConfigValue stores plaintext into c per c.Sensitive: encrypted
+// (ciphertext+nonce) when sensitive, plaintext column otherwise.
+func (s *Server) encodeConfigValue(c *store.AppConfig, plaintext string) error {
+	if c.Sensitive {
+		if s.Secrets == nil {
+			return errors.New("secrets encryption is not configured on this host")
+		}
+		ct, nonce, err := s.Secrets.Seal([]byte(plaintext))
+		if err != nil {
+			return err
+		}
+		c.ValueCiphertext, c.ValueNonce = ct, nonce
+		c.ValuePlaintext = sql.NullString{}
+		return nil
+	}
+	c.ValuePlaintext = sql.NullString{String: plaintext, Valid: true}
+	c.ValueCiphertext, c.ValueNonce = nil, nil
+	return nil
+}
+
+// effectiveConfigValue returns the new plaintext to store: the request's
+// value if provided, otherwise the existing value (decrypted if it was
+// sensitive). Used only internally for re-encoding; never returned via API.
+func (s *Server) effectiveConfigValue(existing *store.AppConfig, reqValue *string) (string, error) {
+	if reqValue != nil {
+		return *reqValue, nil
+	}
+	if existing.Sensitive {
+		if s.Secrets == nil {
+			return "", errors.New("secrets encryption is not configured on this host")
+		}
+		pt, err := s.Secrets.Open(existing.ValueCiphertext, existing.ValueNonce)
+		if err != nil {
+			return "", err
+		}
+		return string(pt), nil
+	}
+	return existing.ValuePlaintext.String, nil
+}
+
+// auditConfig records a config mutation. The value is NEVER included.
+func (s *Server) auditConfig(r *http.Request, action, appID, key string) {
+	s.auditAction(r, audit.Entry{
+		Action: action, Target: appID,
+		Detail: map[string]any{"key": key},
+	})
+}

--- a/control-plane/internal/api/v1_app_config_test.go
+++ b/control-plane/internal/api/v1_app_config_test.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sandboxd/control-plane/internal/auth"
+	"github.com/sandboxd/control-plane/internal/secrets"
+	"github.com/sandboxd/control-plane/internal/store"
+)
+
+const cfgTenant = "tenant-1"
+
+func newConfigTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	st, err := store.Open(context.Background(), "file::memory:?_fk=1", "../../migrations")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	cipher, err := secrets.Load("", filepath.Join(t.TempDir(), "secrets.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{Store: st, Secrets: cipher, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	app := &store.App{ID: "01APPCFG0000000000000001", OwnerToken: cfgTenant, Name: "App"}
+	if err := st.CreateApp(context.Background(), app); err != nil {
+		t.Fatal(err)
+	}
+	return s, app.ID
+}
+
+func do(s *Server, method, target, body, tenant string, pathVals map[string]string) *httptest.ResponseRecorder {
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	r = r.WithContext(auth.WithActor(r.Context(), auth.Actor{Name: tenant, Kind: "service"}))
+	for k, v := range pathVals {
+		r.SetPathValue(k, v)
+	}
+	w := httptest.NewRecorder()
+	switch {
+	case method == "POST" && strings.HasSuffix(target, "/config"):
+		s.v1CreateAppConfig(w, r)
+	case method == "GET":
+		s.v1ListAppConfig(w, r)
+	case method == "PATCH":
+		s.v1PatchAppConfig(w, r)
+	case method == "DELETE":
+		s.v1DeleteAppConfig(w, r)
+	}
+	return w
+}
+
+func TestAppConfigSensitiveEncryptedAndRedacted(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	const secret = "sk-super-secret-9999"
+
+	w := do(s, "POST", "/v1/apps/"+appID+"/config",
+		`{"key":"OPENAI_API_KEY","value":"`+secret+`","sensitive":true}`,
+		cfgTenant, map[string]string{"id": appID})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", w.Code, w.Body)
+	}
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatal("create response leaked the plaintext secret")
+	}
+
+	// Encrypted at rest: ciphertext present, no plaintext column, and the
+	// stored bytes don't contain the secret.
+	c, err := s.Store.GetAppConfig(context.Background(), appID, "OPENAI_API_KEY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.ValueCiphertext) == 0 || c.ValuePlaintext.Valid {
+		t.Errorf("sensitive value not stored as ciphertext: %+v", c)
+	}
+	if bytes.Contains(c.ValueCiphertext, []byte(secret)) {
+		t.Error("ciphertext contains the plaintext secret")
+	}
+	if c.AccessPolicy != "control_plane_only" {
+		t.Errorf("default access_policy = %q; want control_plane_only", c.AccessPolicy)
+	}
+
+	// GET returns metadata only — never the plaintext.
+	g := do(s, "GET", "/v1/apps/"+appID+"/config", "", cfgTenant, map[string]string{"id": appID})
+	if strings.Contains(g.Body.String(), secret) {
+		t.Fatal("GET leaked the plaintext secret")
+	}
+	var got struct {
+		Config []v1ConfigItem `json:"config"`
+	}
+	json.Unmarshal(g.Body.Bytes(), &got)
+	if len(got.Config) != 1 || got.Config[0].Value != nil || !got.Config[0].ValueSet || !got.Config[0].Sensitive {
+		t.Errorf("redaction wrong: %+v", got.Config)
+	}
+}
+
+func TestAppConfigNonSensitiveReturnsValue(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	do(s, "POST", "/v1/apps/"+appID+"/config",
+		`{"key":"API_URL","value":"https://api.example.com","sensitive":false,"access_policy":"runtime_access"}`,
+		cfgTenant, map[string]string{"id": appID})
+
+	g := do(s, "GET", "/v1/apps/"+appID+"/config", "", cfgTenant, map[string]string{"id": appID})
+	var got struct {
+		Config []v1ConfigItem `json:"config"`
+	}
+	json.Unmarshal(g.Body.Bytes(), &got)
+	if len(got.Config) != 1 || got.Config[0].Value == nil || *got.Config[0].Value != "https://api.example.com" {
+		t.Errorf("non-sensitive value not returned: %+v", got.Config)
+	}
+	if got.Config[0].AccessPolicy != "runtime_access" {
+		t.Errorf("access_policy = %q; want runtime_access", got.Config[0].AccessPolicy)
+	}
+}
+
+func TestAppConfigTenantScoping(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	do(s, "POST", "/v1/apps/"+appID+"/config", `{"key":"K","value":"v"}`, cfgTenant, map[string]string{"id": appID})
+
+	// A different tenant cannot read this app's config — the app is 404 to them.
+	w := do(s, "GET", "/v1/apps/"+appID+"/config", "", "tenant-2", map[string]string{"id": appID})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("cross-tenant GET = %d; want 404", w.Code)
+	}
+	// ...nor write it.
+	c := do(s, "POST", "/v1/apps/"+appID+"/config", `{"key":"X","value":"v"}`, "tenant-2", map[string]string{"id": appID})
+	if c.Code != http.StatusNotFound {
+		t.Errorf("cross-tenant POST = %d; want 404", c.Code)
+	}
+}
+
+func TestAppConfigToggleSensitivityReEncrypts(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	// Start non-sensitive (plaintext stored), then mark sensitive via PATCH.
+	do(s, "POST", "/v1/apps/"+appID+"/config", `{"key":"TOK","value":"plain-then-secret"}`, cfgTenant, map[string]string{"id": appID})
+	do(s, "PATCH", "/v1/apps/"+appID+"/config/TOK", `{"sensitive":true}`, cfgTenant, map[string]string{"id": appID, "key": "TOK"})
+
+	c, _ := s.Store.GetAppConfig(context.Background(), appID, "TOK")
+	if !c.Sensitive || len(c.ValueCiphertext) == 0 || c.ValuePlaintext.Valid {
+		t.Errorf("toggle to sensitive did not encrypt: %+v", c)
+	}
+	pt, err := s.Secrets.Open(c.ValueCiphertext, c.ValueNonce)
+	if err != nil || string(pt) != "plain-then-secret" {
+		t.Errorf("re-encrypted value wrong: %q %v", pt, err)
+	}
+}

--- a/control-plane/internal/api/v1_app_config_test.go
+++ b/control-plane/internal/api/v1_app_config_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sandboxd/control-plane/internal/audit"
 	"github.com/sandboxd/control-plane/internal/auth"
 	"github.com/sandboxd/control-plane/internal/secrets"
 	"github.com/sandboxd/control-plane/internal/store"
@@ -155,5 +156,63 @@ func TestAppConfigToggleSensitivityReEncrypts(t *testing.T) {
 	pt, err := s.Secrets.Open(c.ValueCiphertext, c.ValueNonce)
 	if err != nil || string(pt) != "plain-then-secret" {
 		t.Errorf("re-encrypted value wrong: %q %v", pt, err)
+	}
+}
+
+// A PATCH that doesn't include `value` must not touch the stored secret.
+func TestAppConfigPatchPreservesSecretWithoutValue(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	const secret = "sk-keep-me-2222"
+	do(s, "POST", "/v1/apps/"+appID+"/config",
+		`{"key":"K","value":"`+secret+`","sensitive":true,"access_policy":"control_plane_only"}`,
+		cfgTenant, map[string]string{"id": appID})
+	before, _ := s.Store.GetAppConfig(context.Background(), appID, "K")
+
+	// Change only the access policy — no `value` field present.
+	w := do(s, "PATCH", "/v1/apps/"+appID+"/config/K", `{"access_policy":"agent_access"}`,
+		cfgTenant, map[string]string{"id": appID, "key": "K"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: %d %s", w.Code, w.Body)
+	}
+	after, _ := s.Store.GetAppConfig(context.Background(), appID, "K")
+	if after.AccessPolicy != "agent_access" {
+		t.Errorf("policy not updated: %q", after.AccessPolicy)
+	}
+	if !bytes.Equal(after.ValueCiphertext, before.ValueCiphertext) || !bytes.Equal(after.ValueNonce, before.ValueNonce) {
+		t.Error("policy-only PATCH changed the stored secret bytes")
+	}
+	pt, err := s.Secrets.Open(after.ValueCiphertext, after.ValueNonce)
+	if err != nil || string(pt) != secret {
+		t.Errorf("secret altered by a value-less PATCH: %q %v", pt, err)
+	}
+}
+
+type captureAudit struct{ rows []string }
+
+func (c *captureAudit) InsertAudit(_ context.Context, _ int64, _, _, _, _, action, target, detail string) error {
+	c.rows = append(c.rows, action+" "+target+" "+detail)
+	return nil
+}
+
+// Audit rows record the config key, never the secret value.
+func TestAppConfigAuditRecordsKeyNotValue(t *testing.T) {
+	s, appID := newConfigTestServer(t)
+	cap := &captureAudit{}
+	s.Audit = audit.New(cap, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	const secret = "sk-not-in-audit-7777"
+	do(s, "POST", "/v1/apps/"+appID+"/config",
+		`{"key":"OPENAI_API_KEY","value":"`+secret+`","sensitive":true}`,
+		cfgTenant, map[string]string{"id": appID})
+
+	if len(cap.rows) == 0 {
+		t.Fatal("no audit row written for config create")
+	}
+	joined := strings.Join(cap.rows, "\n")
+	if !strings.Contains(joined, "OPENAI_API_KEY") {
+		t.Errorf("audit missing the key name: %s", joined)
+	}
+	if strings.Contains(joined, secret) {
+		t.Errorf("audit leaked the secret value: %s", joined)
 	}
 }

--- a/control-plane/internal/secrets/secrets.go
+++ b/control-plane/internal/secrets/secrets.go
@@ -1,0 +1,89 @@
+// Package secrets encrypts app config values at rest with AES-256-GCM
+// (standard-library crypto only). The master key comes from
+// SANDBOXD_SECRETS_KEY, or an auto-generated 0600 keyfile under the data
+// dir. No custom crypto, and plaintext is never logged.
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Cipher seals/opens secret values.
+type Cipher struct{ aead cipher.AEAD }
+
+// Load builds a Cipher. If envKey is set it must be base64 for 32 bytes;
+// otherwise a key is read from keyfilePath, or generated and written
+// there with 0600 permissions.
+func Load(envKey, keyfilePath string) (*Cipher, error) {
+	key, err := resolveKey(envKey, keyfilePath)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+func resolveKey(envKey, keyfilePath string) ([]byte, error) {
+	if envKey != "" {
+		key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(envKey))
+		if err != nil {
+			return nil, fmt.Errorf("SANDBOXD_SECRETS_KEY is not valid base64: %w", err)
+		}
+		if len(key) != 32 {
+			return nil, fmt.Errorf("SANDBOXD_SECRETS_KEY must decode to 32 bytes, got %d", len(key))
+		}
+		return key, nil
+	}
+	if b, err := os.ReadFile(keyfilePath); err == nil {
+		key, derr := base64.StdEncoding.DecodeString(strings.TrimSpace(string(b)))
+		if derr != nil || len(key) != 32 {
+			return nil, fmt.Errorf("secrets keyfile %s is corrupt (want base64 of 32 bytes)", keyfilePath)
+		}
+		return key, nil
+	}
+	// Generate and persist a fresh key.
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Dir(keyfilePath), 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(keyfilePath, []byte(base64.StdEncoding.EncodeToString(key)), 0o600); err != nil {
+		return nil, fmt.Errorf("write secrets keyfile: %w", err)
+	}
+	return key, nil
+}
+
+// Seal encrypts plaintext, returning the ciphertext and the random nonce
+// used (store both; the nonce is not secret).
+func (c *Cipher) Seal(plaintext []byte) (ciphertext, nonce []byte, err error) {
+	nonce = make([]byte, c.aead.NonceSize())
+	if _, err = rand.Read(nonce); err != nil {
+		return nil, nil, err
+	}
+	return c.aead.Seal(nil, nonce, plaintext, nil), nonce, nil
+}
+
+// Open decrypts ciphertext sealed with nonce. Fails if either was tampered.
+func (c *Cipher) Open(ciphertext, nonce []byte) ([]byte, error) {
+	if len(nonce) != c.aead.NonceSize() {
+		return nil, errors.New("secrets: wrong nonce length")
+	}
+	return c.aead.Open(nil, nonce, ciphertext, nil)
+}

--- a/control-plane/internal/secrets/secrets_test.go
+++ b/control-plane/internal/secrets/secrets_test.go
@@ -1,0 +1,81 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	c, err := Load("", filepath.Join(t.TempDir(), "secrets.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pt := []byte("sk-super-secret-value")
+	ct, nonce, err := c.Seal(pt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(ct, pt) {
+		t.Fatal("ciphertext contains the plaintext")
+	}
+	got, err := c.Open(ct, nonce)
+	if err != nil || !bytes.Equal(got, pt) {
+		t.Fatalf("open = %q, %v; want round-trip", got, err)
+	}
+}
+
+func TestSealUsesFreshNonce(t *testing.T) {
+	c, _ := Load("", filepath.Join(t.TempDir(), "k"))
+	_, n1, _ := c.Seal([]byte("x"))
+	_, n2, _ := c.Seal([]byte("x"))
+	if bytes.Equal(n1, n2) {
+		t.Error("nonce reused across two Seals")
+	}
+}
+
+func TestOpenRejectsTamper(t *testing.T) {
+	c, _ := Load("", filepath.Join(t.TempDir(), "k"))
+	ct, nonce, _ := c.Seal([]byte("value"))
+	ct[0] ^= 0xff // flip a bit
+	if _, err := c.Open(ct, nonce); err == nil {
+		t.Error("tampered ciphertext decrypted without error")
+	}
+}
+
+func TestKeyfileGeneratedWith0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "secrets.key")
+	if _, err := Load("", path); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Errorf("keyfile perms = %v; want 0600", fi.Mode().Perm())
+	}
+	// A second Load reuses the same key (stable across restarts).
+	c1, _ := Load("", path)
+	c2, _ := Load("", path)
+	ct, nonce, _ := c1.Seal([]byte("persisted"))
+	got, err := c2.Open(ct, nonce)
+	if err != nil || string(got) != "persisted" {
+		t.Errorf("key not stable across loads: %q %v", got, err)
+	}
+}
+
+func TestEnvKeyValidation(t *testing.T) {
+	good := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	if _, err := Load(good, ""); err != nil {
+		t.Errorf("valid 32-byte env key rejected: %v", err)
+	}
+	if _, err := Load(base64.StdEncoding.EncodeToString(make([]byte, 16)), ""); err == nil {
+		t.Error("16-byte key accepted; want error")
+	}
+	if _, err := Load("not-base64!!", ""); err == nil {
+		t.Error("non-base64 key accepted; want error")
+	}
+}

--- a/control-plane/internal/store/app_config.go
+++ b/control-plane/internal/store/app_config.go
@@ -1,0 +1,137 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// AppConfig is one app-scoped config entry (migrations/0014). For
+// sensitive entries ValueCiphertext+ValueNonce are set and
+// ValuePlaintext is null; for non-sensitive entries it is the reverse.
+// Encryption happens in the API layer — the store only persists bytes.
+type AppConfig struct {
+	ID              string
+	AppID           string
+	Key             string
+	ValueCiphertext []byte
+	ValueNonce      []byte
+	ValuePlaintext  sql.NullString
+	Sensitive       bool
+	AccessPolicy    string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+const appConfigCols = `id, app_id, key, value_ciphertext, value_nonce,
+	       value_plaintext, sensitive, access_policy, created_at, updated_at`
+
+func scanAppConfig(sc scanner) (*AppConfig, error) {
+	c := &AppConfig{}
+	var created, updated int64
+	var sensitive int
+	err := sc.Scan(&c.ID, &c.AppID, &c.Key, &c.ValueCiphertext, &c.ValueNonce,
+		&c.ValuePlaintext, &sensitive, &c.AccessPolicy, &created, &updated)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	c.Sensitive = sensitive == 1
+	c.CreatedAt = time.Unix(created, 0).UTC()
+	c.UpdatedAt = time.Unix(updated, 0).UTC()
+	return c, nil
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// CreateAppConfig inserts a config entry. ErrConflict if (app_id, key) exists.
+func (s *Store) CreateAppConfig(ctx context.Context, c *AppConfig) error {
+	return s.submit(ctx, func(db *sql.DB) error {
+		now := time.Now().Unix()
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO app_config
+			  (id, app_id, key, value_ciphertext, value_nonce, value_plaintext,
+			   sensitive, access_policy, created_at, updated_at)
+			VALUES (?,?,?,?,?,?,?,?,?,?)`,
+			c.ID, c.AppID, c.Key, c.ValueCiphertext, c.ValueNonce, c.ValuePlaintext,
+			boolToInt(c.Sensitive), c.AccessPolicy, now, now)
+		if isUniqueViolation(err) {
+			return ErrConflict
+		}
+		if err == nil {
+			c.CreatedAt = time.Unix(now, 0).UTC()
+			c.UpdatedAt = c.CreatedAt
+		}
+		return err
+	})
+}
+
+// ListAppConfig returns an app's config entries, ordered by key.
+func (s *Store) ListAppConfig(ctx context.Context, appID string) ([]*AppConfig, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+appConfigCols+` FROM app_config WHERE app_id = ? ORDER BY key`, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*AppConfig
+	for rows.Next() {
+		c, err := scanAppConfig(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// GetAppConfig returns one entry by (app_id, key), or ErrNotFound.
+func (s *Store) GetAppConfig(ctx context.Context, appID, key string) (*AppConfig, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+appConfigCols+` FROM app_config WHERE app_id = ? AND key = ?`, appID, key)
+	return scanAppConfig(row)
+}
+
+// UpdateAppConfig replaces the value/sensitive/access_policy of an entry.
+// The caller supplies the fully-resolved new value fields. ErrNotFound
+// when no entry matches.
+func (s *Store) UpdateAppConfig(ctx context.Context, appID, key string, c *AppConfig) error {
+	return s.submit(ctx, func(db *sql.DB) error {
+		res, err := db.ExecContext(ctx, `
+			UPDATE app_config
+			   SET value_ciphertext = ?, value_nonce = ?, value_plaintext = ?,
+			       sensitive = ?, access_policy = ?, updated_at = ?
+			 WHERE app_id = ? AND key = ?`,
+			c.ValueCiphertext, c.ValueNonce, c.ValuePlaintext,
+			boolToInt(c.Sensitive), c.AccessPolicy, time.Now().Unix(), appID, key)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// DeleteAppConfig removes one entry. ErrNotFound when nothing matched.
+func (s *Store) DeleteAppConfig(ctx context.Context, appID, key string) error {
+	return s.submit(ctx, func(db *sql.DB) error {
+		res, err := db.ExecContext(ctx, `DELETE FROM app_config WHERE app_id = ? AND key = ?`, appID, key)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}

--- a/control-plane/migrations/0014_app_config.sql
+++ b/control-plane/migrations/0014_app_config.sql
@@ -1,0 +1,20 @@
+-- App-scoped config and secrets, owned by the control plane (not Docker
+-- env, workspace files, or task logs). Sensitive values are stored as
+-- AES-256-GCM ciphertext + nonce and are write-only over the API;
+-- non-sensitive config may keep a plaintext value. access_policy governs
+-- who may later request the value through the broker; default is the
+-- safest: control_plane_only (never leaves sandboxd).
+CREATE TABLE app_config (
+    id               TEXT PRIMARY KEY,            -- ULID
+    app_id           TEXT NOT NULL,
+    key              TEXT NOT NULL,
+    value_ciphertext BLOB,                        -- set when sensitive
+    value_nonce      BLOB,                        -- set when sensitive
+    value_plaintext  TEXT,                        -- set when not sensitive
+    sensitive        INTEGER NOT NULL DEFAULT 0,
+    access_policy    TEXT NOT NULL DEFAULT 'control_plane_only',
+    created_at       INTEGER NOT NULL,
+    updated_at       INTEGER NOT NULL,
+    UNIQUE (app_id, key)
+);
+CREATE INDEX idx_app_config_app ON app_config(app_id);


### PR DESCRIPTION
Adds control-plane-owned config and secrets per app, so sensitive values never live in Docker env, workspace files, or task logs.

## What
- **`app_config` table** (migration `0014`), scoped to an app (and therefore to the API tenant). Sensitive entries are stored as **AES-256-GCM ciphertext + a random per-value nonce**; non-sensitive entries may keep a plaintext value.
- **Standard-library crypto only.** Master key from `SANDBOXD_SECRETS_KEY` (base64, 32 bytes) or an auto-generated `0600` keyfile under the data dir.
- **API:** `POST` / `GET` / `PATCH` / `DELETE` `/v1/apps/{id}/config`. Sensitive values are **write-only** — `GET` returns metadata only (`key`, `sensitive`, `access_policy`, `value_set`, timestamps), never the plaintext. Non-sensitive config may be returned in full.
- **`access_policy`** metadata: `control_plane_only` (default) · `agent_access` · `runtime_access` · `both`. Actually *delivering* values to the agent/runtime is a follow-up (a scoped-token broker) — for now nothing is injected, so secrets stay entirely in the control plane.
- Plaintext is **never logged**; audit entries record only the key.

Secrets are deliberately **not** passed through `docker run -e`. The legacy create-time `env` stays for backwards compatibility, but `app_config` is the safer managed replacement.

## Tests
Encryption round-trip / fresh nonce / tamper-detection / `0600` keyfile; sensitive value encrypted at rest and never returned; redaction; default policy; tenant/app scoping (another tenant can't read or write); sensitivity-toggle re-encrypts.

`go build` / `go vet` / `gofmt` / `go test ./...` all clean.

## Note
The `/v1/apps/{id}/config` endpoints should be added to `docs/openapi.yaml` (that file lives on the console branch); the route↔spec contract test will flag it when the two land together.