### PR TITLE
Anonymous telemetry heartbeat + update-check

### DIFF
--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -51,6 +52,7 @@ import (
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/secrets"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/snapshot"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/telemetry"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/wake"
 )
 
@@ -402,9 +404,15 @@ func main() {
 		agentProxyURL = ""
 	}
 
+	// Update checker (best-effort): fetches the latest GitHub release, cached
+	// ~6h, and surfaces update_available in GET /v1/settings. nil-safe in the
+	// handler; a background goroutine below keeps its cache warm.
+	updateChecker := &telemetry.Checker{}
+
 	server := &api.Server{
 		Store:               st,
 		Secrets:             secretsCipher,
+		Update:              updateChecker,
 		AgentAuth:           agentAuth,
 		AgentOAuth:          agentOAuth,
 		OpencodeModel:       envDefault("SANDBOXD_OPENCODE_MODEL", ""),
@@ -490,6 +498,62 @@ func main() {
 	// --- Phase 5 background goroutines ---------------------------------
 	gctx, gcancel := context.WithCancel(context.Background())
 	defer gcancel()
+
+	// --- Anonymous telemetry + update check (internal/telemetry) -------
+	// Keep the release-checker cache warm regardless of the telemetry opt-out:
+	// GET /v1/settings surfaces update_available from it, and no data leaves the
+	// host until a client asks. A single fetch every 6h; best-effort.
+	go func() {
+		t := time.NewTicker(6 * time.Hour)
+		defer t.Stop()
+		for {
+			if _, _, err := updateChecker.Latest(gctx); err != nil {
+				log.Debug("update check failed (ignored)", "err", err.Error())
+			}
+			select {
+			case <-gctx.Done():
+				return
+			case <-t.C:
+			}
+		}
+	}()
+
+	// Anonymous usage heartbeat. ON by default; disabled via SANDBOXD_TELEMETRY=off
+	// or DO_NOT_TRACK=1. The reporter only ever sends a random instance UUID, the
+	// version, GOOS/GOARCH, a coarse sandbox-count bucket, and two feature flags —
+	// no hostnames, IPs, paths, or user content (see docs/telemetry.md).
+	if telemetry.EnabledFromEnv(os.Getenv) {
+		instanceID, isNew, idErr := telemetry.InstanceID(filepath.Join(stateDir, "instance-id"))
+		if idErr != nil {
+			log.Warn("telemetry: could not establish instance id — telemetry disabled", "err", idErr.Error())
+		} else {
+			log.Info("telemetry: anonymous version + daily heartbeat enabled (no code/PII); disable with SANDBOXD_TELEMETRY=off")
+			reporter := &telemetry.Reporter{
+				InstanceID: instanceID,
+				Version:    version,
+				Arch:       runtime.GOARCH,
+				OS:         runtime.GOOS,
+				NewInstall: isNew,
+				Send: telemetry.PostHogSend(
+					envDefault("SANDBOXD_POSTHOG_HOST", telemetry.DefaultPostHogHost),
+					envDefault("SANDBOXD_POSTHOG_KEY", telemetry.DefaultPostHogKey),
+				),
+				Snapshot: func() (int, bool, bool) {
+					count := 0
+					if list, err := st.List(gctx); err == nil {
+						count = len(list)
+					}
+					consoleEnabled := false
+					if h, err := st.GetPasswordHash(gctx); err == nil && h != "" {
+						consoleEnabled = true
+					}
+					return count, !authCfg.Disabled, consoleEnabled
+				},
+				Log: log.With("component", "telemetry"),
+			}
+			go reporter.Run(gctx)
+		}
+	}
 
 	// Idle reaper.
 	idle := &reaper.Idle{

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/secrets"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/snapshot"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/telemetry"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/wake"
 )
 
@@ -123,6 +124,10 @@ type Server struct {
 	// Phase 8A — static, safe instance metadata for GET /v1/settings.
 	// Populated in main; contains no secrets.
 	Instance InstanceInfo
+
+	// Update is the best-effort release checker (internal/telemetry). nil-safe:
+	// when unset, GET /v1/settings simply reports update_available=false.
+	Update *telemetry.Checker
 
 	// Phase 8B — live, runtime-editable lifecycle tunables (idle/keepalive),
 	// shared with the reaper. nil-safe: PATCH /v1/settings returns 503 when

--- a/control-plane/internal/api/v1_settings.go
+++ b/control-plane/internal/api/v1_settings.go
@@ -31,16 +31,22 @@ type InstanceInfo struct {
 }
 
 type v1Settings struct {
-	Version      string            `json:"version"`
-	GitCommit    string            `json:"git_commit,omitempty"`
-	Networking   v1SettingsNet     `json:"networking"`
-	Auth         v1SettingsAuth    `json:"auth"`
-	Runtime      v1SettingsRuntime `json:"runtime"`
-	Lifecycle    v1SettingsLife    `json:"lifecycle"`
-	Egress       v1SettingsEgress  `json:"egress"`
-	Agents       v1SettingsAgents  `json:"agents"`
-	Presets      []v1Preset        `json:"presets"`
-	Capabilities map[string]bool   `json:"capabilities"`
+	Version   string `json:"version"`
+	GitCommit string `json:"git_commit,omitempty"`
+	// Update info from the release checker (best-effort). update_available is
+	// always present; latest_version/changelog_url are omitted until a release
+	// has been fetched.
+	UpdateAvailable bool              `json:"update_available"`
+	LatestVersion   string            `json:"latest_version,omitempty"`
+	ChangelogURL    string            `json:"changelog_url,omitempty"`
+	Networking      v1SettingsNet     `json:"networking"`
+	Auth            v1SettingsAuth    `json:"auth"`
+	Runtime         v1SettingsRuntime `json:"runtime"`
+	Lifecycle       v1SettingsLife    `json:"lifecycle"`
+	Egress          v1SettingsEgress  `json:"egress"`
+	Agents          v1SettingsAgents  `json:"agents"`
+	Presets         []v1Preset        `json:"presets"`
+	Capabilities    map[string]bool   `json:"capabilities"`
 	// Editable lists the field paths a client may change via PATCH /v1/settings.
 	// Everything else is read-only (env/file-managed or restart-required).
 	Editable []string `json:"editable"`
@@ -123,6 +129,9 @@ func (s *Server) v1GetSettings(w http.ResponseWriter, _ *http.Request) {
 			"lifecycle.idle_threshold_seconds",
 			"lifecycle.keepalive_max_seconds",
 		}
+	}
+	if s.Update != nil {
+		out.UpdateAvailable, out.LatestVersion, out.ChangelogURL = s.Update.UpdateAvailable(s.Instance.Version)
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/control-plane/internal/api/v1_settings_test.go
+++ b/control-plane/internal/api/v1_settings_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/secrets"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/telemetry"
 )
 
 // GET /v1/settings returns a stable, safe shape and never leaks the encryption
@@ -83,5 +85,49 @@ func TestV1SettingsShapeAndNoSecretLeak(t *testing.T) {
 		if !ids[want] {
 			t.Errorf("settings presets missing %q", want)
 		}
+	}
+
+	// No update checker wired → update_available is present and false.
+	if m["update_available"] != false {
+		t.Errorf("update_available should default to false, got %v", m["update_available"])
+	}
+}
+
+// With an update checker whose cache holds a newer release, GET /v1/settings
+// surfaces update_available + latest_version + changelog_url.
+func TestV1SettingsUpdateAvailable(t *testing.T) {
+	chk := &telemetry.Checker{
+		Fetch: func(context.Context) (string, string, error) {
+			return "v0.5.0", "https://github.com/tastyeffectco/sandboxd/releases/tag/v0.5.0", nil
+		},
+	}
+	if _, _, err := chk.Latest(context.Background()); err != nil {
+		t.Fatalf("warm checker cache: %v", err)
+	}
+
+	s := &Server{
+		PreviewDomain: "ex.sslip.io",
+		Image:         "sandboxd-base:test",
+		Update:        chk,
+		Instance:      InstanceInfo{Version: "v0.4.0", AgentProviders: []string{"opencode"}},
+	}
+
+	w := httptest.NewRecorder()
+	s.v1GetSettings(w, httptest.NewRequest("GET", "/v1/settings", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &m); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if m["update_available"] != true {
+		t.Errorf("update_available should be true (v0.5.0 > v0.4.0), got %v", m["update_available"])
+	}
+	if m["latest_version"] != "v0.5.0" {
+		t.Errorf("latest_version = %v", m["latest_version"])
+	}
+	if m["changelog_url"] == "" || m["changelog_url"] == nil {
+		t.Errorf("changelog_url should be populated, got %v", m["changelog_url"])
 	}
 }

--- a/control-plane/internal/telemetry/telemetry.go
+++ b/control-plane/internal/telemetry/telemetry.go
@@ -1,0 +1,237 @@
+// Package telemetry implements sandboxd's anonymous, opt-out usage
+// heartbeat and its GitHub-backed update check.
+//
+// What it sends is deliberately minimal and non-identifying: a random
+// instance UUID (generated locally, never derived from any host detail),
+// the build version, GOOS/GOARCH, a coarse sandbox-count bucket, and two
+// feature booleans. It never sends hostnames, IP addresses, file paths,
+// tokens, or any user content. See docs/telemetry.md for the exact list.
+//
+// Telemetry is ON by default and can be disabled with SANDBOXD_TELEMETRY=off
+// (or the cross-tool DO_NOT_TRACK=1). Every network send is best-effort with
+// a short timeout: a failing or slow endpoint can never block or crash the
+// daemon.
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultPostHogHost / DefaultPostHogKey are the project's public capture
+	// endpoint. The phc_ key is a write-only client key (safe to embed — it can
+	// only append events, never read them). Both are overridable via
+	// SANDBOXD_POSTHOG_HOST / SANDBOXD_POSTHOG_KEY.
+	DefaultPostHogHost = "https://us.i.posthog.com"
+	DefaultPostHogKey  = "phc_vyQtLTZPBHwEBcY8mcfneP43xAFGLzFVic9DhQ7VGrqV"
+
+	// defaultInterval is the heartbeat cadence once running.
+	defaultInterval = 24 * time.Hour
+
+	// sendTimeout caps a single capture POST so a hung endpoint never wedges
+	// the reporter goroutine.
+	sendTimeout = 15 * time.Second
+)
+
+// EnabledFromEnv reports whether telemetry should run. It is ON by default and
+// returns false only when the operator has explicitly opted out: SANDBOXD_TELEMETRY
+// set to off/0/false/no (case-insensitive), or the cross-tool DO_NOT_TRACK set to
+// 1/true/yes. `get` is an env accessor (os.Getenv in production; a map in tests).
+func EnabledFromEnv(get func(string) string) bool {
+	switch strings.ToLower(strings.TrimSpace(get("SANDBOXD_TELEMETRY"))) {
+	case "off", "0", "false", "no":
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(get("DO_NOT_TRACK"))) {
+	case "1", "true", "yes":
+		return false
+	}
+	return true
+}
+
+// InstanceID reads (or, on first run, generates and persists) the anonymous
+// instance UUID stored at path. The id is random (crypto/rand) — it is NOT
+// derived from any machine attribute, so it cannot be correlated back to a host.
+// isNew is true only when the id was just generated, which the caller uses to
+// emit a one-time "install" event. The file is written 0600.
+func InstanceID(path string) (id string, isNew bool, err error) {
+	if b, rerr := os.ReadFile(path); rerr == nil {
+		if s := strings.TrimSpace(string(b)); s != "" {
+			return s, false, nil
+		}
+	}
+	id, err = newUUIDv4()
+	if err != nil {
+		return "", false, err
+	}
+	if err = os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return "", false, err
+	}
+	if err = os.WriteFile(path, []byte(id+"\n"), 0o600); err != nil {
+		return "", false, err
+	}
+	return id, true, nil
+}
+
+// newUUIDv4 returns a random RFC-4122 version-4 UUID string (8-4-4-4-12 hex).
+func newUUIDv4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // RFC-4122 variant
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// heartbeatProps builds the event properties. sandbox count is bucketed (never
+// sent as an exact number) and "$ip" is forced to "" so PostHog neither stores
+// nor geolocates the caller's IP. No hostnames, paths, or user content ever
+// appear here.
+func heartbeatProps(version, arch, osName string, sandboxCount int, authEnabled, consoleEnabled bool) map[string]any {
+	return map[string]any{
+		"version":         version,
+		"arch":            arch,
+		"os":              osName,
+		"sandbox_bucket":  bucketCount(sandboxCount),
+		"auth_enabled":    authEnabled,
+		"console_enabled": consoleEnabled,
+		// Empty $ip tells PostHog to drop the request IP (no geo, no storage).
+		"$ip": "",
+	}
+}
+
+func bucketCount(n int) string {
+	switch {
+	case n <= 0:
+		return "0"
+	case n <= 3:
+		return "1-3"
+	case n <= 10:
+		return "4-10"
+	default:
+		return "10+"
+	}
+}
+
+// SendFunc delivers one event. It is injectable so tests never touch the
+// network; PostHogSend is the production implementation.
+type SendFunc func(ctx context.Context, event string, props map[string]any) error
+
+// Reporter periodically emits the anonymous heartbeat. All fields are plain
+// values so it is trivial to construct in main and in tests.
+type Reporter struct {
+	InstanceID string
+	Version    string
+	Arch       string
+	OS         string
+	// NewInstall, when true, makes Run emit a one-time "install" event before
+	// the first heartbeat.
+	NewInstall bool
+	// Interval is the heartbeat cadence; zero means the 24h default. Tests set
+	// it small.
+	Interval time.Duration
+	// Send delivers each event (best-effort). nil disables sending.
+	Send SendFunc
+	// Snapshot supplies the live counters at send time. nil → zero/false.
+	Snapshot func() (sandboxCount int, authEnabled, consoleEnabled bool)
+	Log      *slog.Logger
+}
+
+// Run emits an optional install event, an immediate heartbeat, then a heartbeat
+// every Interval until ctx is done. Every send is best-effort: errors are logged
+// and swallowed so the loop — and the daemon — keep running.
+func (r *Reporter) Run(ctx context.Context) {
+	interval := r.Interval
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+	if r.NewInstall {
+		r.emit(ctx, "install")
+	}
+	r.emit(ctx, "heartbeat")
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			r.emit(ctx, "heartbeat")
+		}
+	}
+}
+
+func (r *Reporter) emit(ctx context.Context, event string) {
+	if r.Send == nil {
+		return
+	}
+	count, authEnabled, consoleEnabled := 0, false, false
+	if r.Snapshot != nil {
+		count, authEnabled, consoleEnabled = r.Snapshot()
+	}
+	props := heartbeatProps(r.Version, r.Arch, r.OS, count, authEnabled, consoleEnabled)
+	// The sender lifts distinct_id to the top level of the PostHog payload.
+	props["distinct_id"] = r.InstanceID
+
+	sctx, cancel := context.WithTimeout(ctx, sendTimeout)
+	defer cancel()
+	if err := r.Send(sctx, event, props); err != nil && r.Log != nil {
+		r.Log.Debug("telemetry send failed (ignored)", "event", event, "err", err.Error())
+	}
+}
+
+// PostHogSend returns a SendFunc that posts a single capture event to a PostHog
+// instance. The distinct_id is read from props (set by Reporter.emit) and lifted
+// to the top level; it is not duplicated inside properties.
+func PostHogSend(host, apiKey string) SendFunc {
+	client := &http.Client{Timeout: 10 * time.Second}
+	endpoint := strings.TrimRight(host, "/") + "/i/v0/e/"
+	return func(ctx context.Context, event string, props map[string]any) error {
+		distinctID, _ := props["distinct_id"].(string)
+		properties := make(map[string]any, len(props))
+		for k, v := range props {
+			if k == "distinct_id" {
+				continue
+			}
+			properties[k] = v
+		}
+		body, err := json.Marshal(map[string]any{
+			"api_key":     apiKey,
+			"event":       event,
+			"distinct_id": distinctID,
+			"properties":  properties,
+			"timestamp":   time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			return err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("posthog: unexpected status %d", resp.StatusCode)
+		}
+		return nil
+	}
+}

--- a/control-plane/internal/telemetry/telemetry_test.go
+++ b/control-plane/internal/telemetry/telemetry_test.go
@@ -1,0 +1,217 @@
+package telemetry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEnabledFromEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"default on (nothing set)", map[string]string{}, true},
+		{"SANDBOXD_TELEMETRY=off", map[string]string{"SANDBOXD_TELEMETRY": "off"}, false},
+		{"SANDBOXD_TELEMETRY=OFF (case)", map[string]string{"SANDBOXD_TELEMETRY": "OFF"}, false},
+		{"SANDBOXD_TELEMETRY=0", map[string]string{"SANDBOXD_TELEMETRY": "0"}, false},
+		{"SANDBOXD_TELEMETRY=false", map[string]string{"SANDBOXD_TELEMETRY": "false"}, false},
+		{"SANDBOXD_TELEMETRY=no", map[string]string{"SANDBOXD_TELEMETRY": "no"}, false},
+		{"SANDBOXD_TELEMETRY=on stays on", map[string]string{"SANDBOXD_TELEMETRY": "on"}, true},
+		{"SANDBOXD_TELEMETRY=1 stays on", map[string]string{"SANDBOXD_TELEMETRY": "1"}, true},
+		{"DO_NOT_TRACK=1", map[string]string{"DO_NOT_TRACK": "1"}, false},
+		{"DO_NOT_TRACK=true", map[string]string{"DO_NOT_TRACK": "true"}, false},
+		{"DO_NOT_TRACK=YES (case)", map[string]string{"DO_NOT_TRACK": "YES"}, false},
+		{"DO_NOT_TRACK=0 stays on", map[string]string{"DO_NOT_TRACK": "0"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			get := func(k string) string { return tc.env[k] }
+			if got := EnabledFromEnv(get); got != tc.want {
+				t.Fatalf("EnabledFromEnv() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+var uuidRE = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+func TestInstanceIDGeneratePersistReread(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "instance-id")
+
+	id, isNew, err := InstanceID(path)
+	if err != nil {
+		t.Fatalf("first InstanceID: %v", err)
+	}
+	if !isNew {
+		t.Fatal("first call should report isNew=true")
+	}
+	if !uuidRE.MatchString(id) {
+		t.Fatalf("generated id %q is not a v4-shaped UUID", id)
+	}
+
+	// File perms must be 0600.
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("instance-id perms = %o, want 600", perm)
+	}
+
+	// Second call is idempotent: same id, isNew=false.
+	id2, isNew2, err := InstanceID(path)
+	if err != nil {
+		t.Fatalf("second InstanceID: %v", err)
+	}
+	if id2 != id {
+		t.Fatalf("second id %q != first %q", id2, id)
+	}
+	if isNew2 {
+		t.Fatal("second call should report isNew=false")
+	}
+}
+
+func TestHeartbeatPropsBucketing(t *testing.T) {
+	cases := []struct {
+		count int
+		want  string
+	}{
+		{-1, "0"},
+		{0, "0"},
+		{1, "1-3"},
+		{3, "1-3"},
+		{4, "4-10"},
+		{10, "4-10"},
+		{11, "10+"},
+		{500, "10+"},
+	}
+	for _, tc := range cases {
+		props := heartbeatProps("v0.3.0", "arm64", "linux", tc.count, true, false)
+		if got := props["sandbox_bucket"]; got != tc.want {
+			t.Errorf("count=%d bucket=%v want %v", tc.count, got, tc.want)
+		}
+	}
+}
+
+func TestHeartbeatPropsNoIPAndFields(t *testing.T) {
+	props := heartbeatProps("v0.3.0", "amd64", "darwin", 2, true, true)
+
+	// $ip must be present and EMPTY so PostHog does not geolocate/store IP.
+	ip, ok := props["$ip"]
+	if !ok {
+		t.Fatal("props missing $ip")
+	}
+	if ip != "" {
+		t.Fatalf("$ip = %q, want empty string", ip)
+	}
+
+	if props["version"] != "v0.3.0" {
+		t.Errorf("version = %v", props["version"])
+	}
+	if props["arch"] != "amd64" {
+		t.Errorf("arch = %v", props["arch"])
+	}
+	if props["os"] != "darwin" {
+		t.Errorf("os = %v", props["os"])
+	}
+	if props["auth_enabled"] != true {
+		t.Errorf("auth_enabled = %v", props["auth_enabled"])
+	}
+	if props["console_enabled"] != true {
+		t.Errorf("console_enabled = %v", props["console_enabled"])
+	}
+
+	// No PII fields must ever leak in.
+	for _, bad := range []string{"hostname", "host", "path", "ip", "user", "email"} {
+		if _, present := props[bad]; present {
+			t.Errorf("props leaked PII-ish key %q", bad)
+		}
+	}
+}
+
+func TestReporterRunSendsInstallAndHeartbeat(t *testing.T) {
+	var mu sync.Mutex
+	events := []string{}
+	sent := make(chan string, 16)
+	send := func(_ context.Context, event string, props map[string]any) error {
+		mu.Lock()
+		events = append(events, event)
+		mu.Unlock()
+		sent <- event
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &Reporter{
+		InstanceID: "test-id",
+		Version:    "v0.3.0",
+		Arch:       "arm64",
+		OS:         "linux",
+		NewInstall: true,
+		Interval:   5 * time.Millisecond, // fast tick for the test
+		Send:       send,
+		Snapshot:   func() (int, bool, bool) { return 2, true, false },
+	}
+
+	go r.Run(ctx)
+
+	// Expect: install, then heartbeat, then at least one more heartbeat from the tick.
+	got := []string{}
+	timeout := time.After(2 * time.Second)
+	for len(got) < 3 {
+		select {
+		case e := <-sent:
+			got = append(got, e)
+		case <-timeout:
+			t.Fatalf("timed out; got events = %v", got)
+		}
+	}
+	cancel()
+
+	if got[0] != "install" {
+		t.Errorf("first event = %q, want install", got[0])
+	}
+	if got[1] != "heartbeat" {
+		t.Errorf("second event = %q, want heartbeat", got[1])
+	}
+	if got[2] != "heartbeat" {
+		t.Errorf("third event = %q, want heartbeat", got[2])
+	}
+}
+
+func TestReporterRunSurvivesSendError(t *testing.T) {
+	sent := make(chan struct{}, 16)
+	send := func(_ context.Context, event string, props map[string]any) error {
+		sent <- struct{}{}
+		return context.DeadlineExceeded // always fail
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r := &Reporter{
+		InstanceID: "x",
+		NewInstall: false, // no install event: first send is a heartbeat
+		Interval:   3 * time.Millisecond,
+		Send:       send,
+		Snapshot:   func() (int, bool, bool) { return 0, false, false },
+	}
+	go r.Run(ctx) // must not panic even though every send errors
+
+	// See several sends despite the persistent error (loop keeps going).
+	for i := 0; i < 3; i++ {
+		select {
+		case <-sent:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only saw %d sends; a send error must not stop Run", i)
+		}
+	}
+}

--- a/control-plane/internal/telemetry/update.go
+++ b/control-plane/internal/telemetry/update.go
@@ -1,0 +1,157 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// defaultReleasesURL is the GitHub API endpoint for the latest published release.
+const defaultReleasesURL = "https://api.github.com/repos/tastyeffectco/sandboxd/releases/latest"
+
+// defaultCheckTTL is how long a fetched "latest release" result is trusted before
+// Latest will fetch again.
+const defaultCheckTTL = 6 * time.Hour
+
+// CompareSemver compares two semantic versions and returns -1, 0, or 1 for
+// a<b, a==b, a>b. A leading "v" is ignored, and pre-release/build metadata
+// (anything after "-" or "+") is stripped. Missing or non-numeric components are
+// treated as 0, so malformed input compares as "0.0.0" rather than erroring.
+func CompareSemver(a, b string) int {
+	av, bv := parseSemver(a), parseSemver(b)
+	for i := 0; i < 3; i++ {
+		switch {
+		case av[i] < bv[i]:
+			return -1
+		case av[i] > bv[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseSemver(v string) [3]int {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	var out [3]int
+	for i, part := range strings.SplitN(v, ".", 3) {
+		if i >= 3 {
+			break
+		}
+		if n, err := strconv.Atoi(strings.TrimSpace(part)); err == nil && n > 0 {
+			out[i] = n
+		}
+	}
+	return out
+}
+
+// Checker fetches the latest published release (cached ~6h) and answers whether
+// a newer version than the running build exists. It is best-effort: on any fetch
+// error UpdateAvailable simply reports false. It is safe for concurrent use.
+type Checker struct {
+	// URL overrides the GitHub releases endpoint (tests point this elsewhere).
+	URL string
+	// Fetch overrides the network fetch entirely (used by tests). It returns the
+	// release tag and its html_url.
+	Fetch func(ctx context.Context) (tag, url string, err error)
+	// TTL overrides the cache lifetime; zero means the 6h default.
+	TTL time.Duration
+	// Now overrides the clock (tests); zero-value means time.Now.
+	Now func() time.Time
+
+	mu        sync.Mutex
+	haveData  bool
+	tag       string
+	url       string
+	lastFetch time.Time
+}
+
+func (c *Checker) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+func (c *Checker) ttl() time.Duration {
+	if c.TTL > 0 {
+		return c.TTL
+	}
+	return defaultCheckTTL
+}
+
+// Latest returns the latest release tag and its changelog/release URL, fetching
+// from GitHub at most once per TTL. Callers run this from a background goroutine;
+// the request-path UpdateAvailable never fetches.
+func (c *Checker) Latest(ctx context.Context) (version, url string, err error) {
+	c.mu.Lock()
+	if c.haveData && c.now().Sub(c.lastFetch) < c.ttl() {
+		v, u := c.tag, c.url
+		c.mu.Unlock()
+		return v, u, nil
+	}
+	c.mu.Unlock()
+
+	fetch := c.Fetch
+	if fetch == nil {
+		fetch = c.githubFetch
+	}
+	tag, u, ferr := fetch(ctx)
+	if ferr != nil {
+		return "", "", ferr
+	}
+
+	c.mu.Lock()
+	c.tag, c.url, c.haveData, c.lastFetch = tag, u, true, c.now()
+	c.mu.Unlock()
+	return tag, u, nil
+}
+
+// UpdateAvailable reports, from the cached result only (never the network),
+// whether the latest release is newer than current. It is best-effort: with no
+// cached result yet it returns (false, "", ""). When a result is cached it always
+// returns the latest version + changelog URL so callers can surface them.
+func (c *Checker) UpdateAvailable(current string) (available bool, latest, changelogURL string) {
+	c.mu.Lock()
+	have, tag, url := c.haveData, c.tag, c.url
+	c.mu.Unlock()
+	if !have || tag == "" {
+		return false, "", ""
+	}
+	return CompareSemver(tag, current) > 0, tag, url
+}
+
+func (c *Checker) githubFetch(ctx context.Context) (tag, url string, err error) {
+	endpoint := c.URL
+	if endpoint == "" {
+		endpoint = defaultReleasesURL
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", "", err
+	}
+	return body.TagName, body.HTMLURL, nil
+}

--- a/control-plane/internal/telemetry/update_test.go
+++ b/control-plane/internal/telemetry/update_test.go
@@ -1,0 +1,82 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCompareSemver(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"0.3.0", "0.4.0", -1},
+		{"0.4.0", "0.3.0", 1},
+		{"0.3.0", "0.3.1", -1},
+		{"0.3.1", "0.3.0", 1},
+		{"0.3.0", "0.3.0", 0},
+		{"v0.3.0", "0.3.0", 0},     // v-prefix ignored
+		{"v1.2.3", "v1.2.3", 0},    // both v-prefixed
+		{"1.0.0", "0.9.9", 1},      // major dominates
+		{"0.10.0", "0.9.0", 1},     // numeric, not lexical
+		{"", "0.0.0", 0},           // malformed → 0
+		{"garbage", "0.0.0", 0},    // malformed → 0
+		{"1.2", "1.2.0", 0},        // missing patch → 0
+		{"v0.4.0-rc1", "0.4.0", 0}, // pre-release stripped
+	}
+	for _, tc := range cases {
+		if got := CompareSemver(tc.a, tc.b); got != tc.want {
+			t.Errorf("CompareSemver(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestCheckerUpdateAvailable(t *testing.T) {
+	c := &Checker{
+		Fetch: func(context.Context) (string, string, error) {
+			return "v0.4.0", "https://github.com/tastyeffectco/sandboxd/releases/tag/v0.4.0", nil
+		},
+	}
+	if _, _, err := c.Latest(context.Background()); err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+
+	avail, latest, url := c.UpdateAvailable("0.3.0")
+	if !avail {
+		t.Error("expected update available for current=0.3.0 vs latest=0.4.0")
+	}
+	if latest != "v0.4.0" {
+		t.Errorf("latest = %q", latest)
+	}
+	if url == "" {
+		t.Error("changelog url should be populated")
+	}
+
+	// Current == latest: no update.
+	avail2, _, _ := c.UpdateAvailable("0.4.0")
+	if avail2 {
+		t.Error("no update should be available when current == latest")
+	}
+
+	// Current newer than latest (dev build ahead of release): no update.
+	avail3, _, _ := c.UpdateAvailable("0.5.0")
+	if avail3 {
+		t.Error("no update should be available when current > latest")
+	}
+}
+
+func TestCheckerUpdateAvailableEmptyCacheIsSafe(t *testing.T) {
+	c := &Checker{
+		Fetch: func(context.Context) (string, string, error) {
+			return "", "", context.DeadlineExceeded
+		},
+	}
+	// Latest returns the error; UpdateAvailable must be best-effort false.
+	if _, _, err := c.Latest(context.Background()); err == nil {
+		t.Fatal("expected fetch error")
+	}
+	avail, _, _ := c.UpdateAvailable("0.3.0")
+	if avail {
+		t.Error("empty/failed cache must yield update_available=false")
+	}
+}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,74 @@
+# Telemetry
+
+sandboxd sends a small, anonymous usage heartbeat so the project can see how
+many instances are running and which versions are in use, and so it can tell you
+when a newer release is available. Telemetry is **on by default** and easy to
+turn off.
+
+## What is collected
+
+Each heartbeat contains only these fields:
+
+| Field             | Example        | Notes                                                        |
+| ----------------- | -------------- | ------------------------------------------------------------ |
+| instance UUID     | `9f1c…` (v4)   | Random, generated locally. Not derived from any host detail. |
+| `version`         | `v0.3.0`       | The running build version.                                   |
+| `arch`            | `arm64`        | CPU architecture (`GOARCH`).                                 |
+| `os`              | `linux`        | Operating system (`GOOS`).                                   |
+| `sandbox_bucket`  | `1-3`          | Coarse bucket of the sandbox count: `0`, `1-3`, `4-10`, `10+`. Never an exact number. |
+| `auth_enabled`    | `true`         | Whether API auth is enabled.                                 |
+| `console_enabled` | `false`        | Whether the web console has an admin password set.           |
+
+The request IP address is **not** stored: every event is sent with an empty
+`$ip`, which tells the collector to drop it (no geolocation, no storage).
+
+## What is NOT collected
+
+No hostnames, no IP addresses, no file paths, no environment values, no API
+tokens or credentials, no sandbox names, and no user or code content of any
+kind. The instance UUID is random and cannot be traced back to a machine.
+
+The full payload is built in
+[`internal/telemetry`](../control-plane/internal/telemetry) — it is short and
+worth reading if you want to confirm exactly what leaves the host.
+
+## Why
+
+- **Install / version counts** — a rough sense of how many instances run each
+  version, which guides what to support and when to retire old behaviour.
+- **Update notifications** — sandboxd checks the latest GitHub release and
+  surfaces `update_available` in `GET /v1/settings` so the console can tell you
+  when to upgrade. (The update check runs regardless of the telemetry opt-out;
+  it only *reads* the public releases API and sends nothing.)
+
+## How it works
+
+- On first start, a random UUID is written to `<data>/state/instance-id`
+  (mode `0600`) and a one-time `install` event is sent.
+- A `heartbeat` event is sent at startup and then every 24 hours.
+- Every send is best-effort with a short timeout. A slow or unreachable
+  collector never blocks or crashes sandboxd.
+
+## Opting out
+
+Set either of these before starting sandboxd:
+
+```sh
+SANDBOXD_TELEMETRY=off   # also accepts 0, false, no
+# or the cross-tool standard:
+DO_NOT_TRACK=1           # also accepts true, yes
+```
+
+With telemetry disabled, no heartbeat is sent and no instance UUID event is
+emitted. (The random `instance-id` file may still exist from a prior run; it is
+never sent while telemetry is off.)
+
+### Self-hosting the collector
+
+By default events go to the project's PostHog capture endpoint. You can point
+them at your own instance:
+
+```sh
+SANDBOXD_POSTHOG_HOST=https://your-posthog.example.com
+SANDBOXD_POSTHOG_KEY=phc_your_write_key
+```

--- a/install.sh
+++ b/install.sh
@@ -194,6 +194,8 @@ cat <<EOF
 
   Logs:   $COMPOSE logs -f sandboxd
   Stop:   $COMPOSE down
+
+  Telemetry : anonymous version + daily heartbeat (no code/PII). Opt out: SANDBOXD_TELEMETRY=off
 EOF
 
 if [ "$CONSOLE" = "1" ]; then

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -57,6 +57,7 @@ SANDBOXD_ADDR=127.0.0.1:9191 SANDBOXD_IMAGE="$IMG" SANDBOXD_DATA_DIR="$DD" \
   SANDBOXD_LIBRARY_DIR="$DD/library" SANDBOXD_MIGRATIONS="$HERE/control-plane/migrations" \
   SANDBOXD_DB="$DD/sandboxd.db" SANDBOXD_IDLE_THRESHOLD_SECONDS=3600 \
   SANDBOXD_API_AUTH_DISABLED=true \
+  SANDBOXD_TELEMETRY=off \
   "$BIN" >"$DD/sandboxd.log" 2>&1 &
 SBX_PID=$!
 for i in $(seq 1 60); do curl -s -m2 "$API/healthz" 2>/dev/null | grep -q ok && break; sleep 0.5; done


### PR DESCRIPTION
## What

Adds `internal/telemetry`: an anonymous, opt-out usage heartbeat plus a GitHub-backed release/update check.

## Why

- **Install / version counts** — a rough sense of how many instances run each version, to guide support decisions.
- **Update notifications** — sandboxd checks the latest GitHub release and surfaces `update_available` in `GET /v1/settings` so the console can prompt an upgrade. The update check only reads the public releases API and sends nothing; it runs regardless of the telemetry opt-out.

## The anonymized payload

Each event's properties are exactly:

| Field | Example | Notes |
| --- | --- | --- |
| `distinct_id` (instance UUID) | `9f1c…` (v4) | Random, generated locally at `<state>/instance-id` (0600). Not derived from any host attribute. |
| `version` | `v0.3.0` | Running build version. |
| `arch` | `arm64` | `GOARCH`. |
| `os` | `linux` | `GOOS`. |
| `sandbox_bucket` | `1-3` | Coarse bucket: `0`, `1-3`, `4-10`, `10+`. Never an exact count. |
| `auth_enabled` | `true` | API auth on/off. |
| `console_enabled` | `false` | Whether a console admin password is set. |
| `$ip` | `""` | Empty — PostHog drops the request IP (no geo, no storage). |

**Not collected:** hostnames, IPs, file paths, env values, tokens/credentials, sandbox names, or any user/code content.

Events: a one-time `install` (first run only) and a `heartbeat` at startup + every 24h. Every send is best-effort with a short timeout and can never block or crash the daemon.

## Default-on + opt-out

Telemetry is **on by default**. Disable with either:

- `SANDBOXD_TELEMETRY=off` (also `0`/`false`/`no`)
- `DO_NOT_TRACK=1` (also `true`/`yes`)

A one-line disclosure is logged at startup when telemetry is on, `install.sh` prints an opt-out line, and `docs/telemetry.md` documents the exact payload. Collector is overridable via `SANDBOXD_POSTHOG_HOST`/`SANDBOXD_POSTHOG_KEY`.

## Update-check in /v1/settings

`GET /v1/settings` now returns `update_available`, `latest_version`, and `changelog_url` from a best-effort `Checker` (latest GitHub release, cached ~6h). Nil-safe: when no checker is wired, `update_available` is `false`.

## Tests

TDD throughout. New `internal/telemetry` unit tests (env opt-out matrix, UUID gen/persist/perms, bucketing, `$ip` empty, Reporter install+heartbeat + survives send errors, semver compare, update-available logic) and a settings-handler test for the update fields. Full `go build ./... && go test ./...` is green.