### PR TITLE
Safe in-place upgrade (backup + auto-rollback) + version + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ under **Settings**, create an app, and build. No code needed.
   it? run **`./console-login.sh`** to see it again anytime
 - **API:** `http://127.0.0.1:9090` (`curl http://127.0.0.1:9090/healthz` → `ok`)
 - **Headless (no console):** run with `SANDBOXD_CONSOLE=0` (or `--no-console`)
+- **Upgrade later:** run **`./upgrade.sh`** — it backs up your database first,
+  health-checks the new version, and rolls back automatically if it fails
+  ([Upgrading](docs/upgrading.md)). `./upgrade.sh --check` shows your version.
 
 Prefer the API? Connect an agent once, create a sandbox, hand it a prompt:
 ```bash

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -99,6 +99,10 @@ func main() {
 		switch os.Args[1] {
 		case "backfill-legacy":
 			os.Exit(runBackfillLegacy(os.Args[2:]))
+		case "version", "--version", "-v":
+			v, c := buildIdent()
+			fmt.Printf("sandboxd %s (%s)\n", v, c)
+			os.Exit(0)
 		default:
 			fmt.Fprintf(os.Stderr, "sandboxd: unknown subcommand %q\n", os.Args[1])
 			os.Exit(2)

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,84 @@
+# Upgrading sandboxd
+
+sandboxd upgrades **in place** with a single command. It backs up your database
+and `.env` first, applies new migrations, health-checks the new stack, and
+**rolls back automatically** if the new version doesn't come up — so it's safe to
+run on a production instance.
+
+> Migrations are **additive only** (new tables/columns, never destructive), so an
+> upgrade never rewrites or drops your existing data.
+
+## Check your version
+
+```bash
+./upgrade.sh --check      # shows your current checkout vs the latest release; changes nothing
+```
+
+The running control plane also reports its version and whether an update is
+available (anonymous release check) at `GET /v1/settings` → `version`,
+`update_available`, `latest_version`, `changelog_url`.
+
+## Upgrade
+
+From your sandboxd source directory (the folder with `install.sh`):
+
+```bash
+./upgrade.sh
+```
+
+What it does, in order:
+
+1. **Backs up** the database (`state/sandboxd.db`) and `.env` to
+   `<data-dir>/backups/<timestamp>/`, and records the current commit.
+2. **Fetches** the new code.
+3. **Rebuilds + restarts** the stack (`docker compose build && up -d`). New
+   migrations apply automatically when the control plane boots.
+4. **Health-checks** the new control plane. If it doesn't become healthy, it
+   **restores the backup, reverts the code, and brings the previous version back
+   up**, then exits non-zero.
+
+If it succeeds, your backup is kept at the path printed at the end — delete it
+once you're satisfied.
+
+## Roll back manually
+
+Automatic rollback covers a failed upgrade. To revert a *successful* upgrade you
+weren't happy with, restore from a backup:
+
+```bash
+cd <your-sandboxd-source-dir>
+BK=<data-dir>/backups/<timestamp>          # pick the one you want
+git reset --hard "$(cat "$BK/previous-commit.txt")"
+cp "$BK/sandboxd.db" <data-dir>/state/sandboxd.db
+docker compose --profile console up -d --build
+```
+
+## Pin a specific version
+
+By default `./upgrade.sh` tracks the `main` branch (where releases currently
+land). To pin a tagged release or branch:
+
+```bash
+./upgrade.sh v0.4.0
+```
+
+## Notes
+
+- **Backups accumulate** under `<data-dir>/backups/`. They're small (a SQLite
+  file + `.env`); prune old ones when you like.
+- **Your apps and data are untouched** by an upgrade — only the sandboxd images
+  and schema move forward.
+- **Update detection** relies on the anonymous release check (part of the
+  telemetry heartbeat). It sends no code or personal data and is opt-out with
+  `SANDBOXD_TELEMETRY=off` — the upgrade itself works regardless.
+
+## Troubleshooting
+
+- **"could not reach GitHub"** on `--check` — network/rate-limit; the upgrade
+  still works, it just can't show the latest tag.
+- **Upgrade rolled back** — the new control plane failed its health check. Look
+  at `docker compose logs sandboxd`; your previous version is already running and
+  your data was restored from the backup.
+- **Ran out of disk mid-build** — free space (old images: `docker image prune`)
+  and re-run; your backup from the aborted attempt is still under
+  `<data-dir>/backups/`.

--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,8 @@ if [ -n "$API_KEY" ]; then
   printf '  Send it as:  Authorization: Bearer <key>   (rotate in .env or the console)\n'
 fi
 printf '\n  Lost these later?  run:  ./console-login.sh\n'
+printf '  Update later:      run:  ./upgrade.sh   (backs up first, auto-rollback)\n'
+chmod +x upgrade.sh 2>/dev/null || true
 
 # A single, plain (no-color) nudge — suppress with SANDBOXD_NO_SPONSOR=1.
 [ -z "${SANDBOXD_NO_SPONSOR:-}" ] && printf '\n  \342\230\205 sandboxd is free & MIT. If it saves you time: https://github.com/sponsors/tastyeffectco\n'

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# sandboxd — safe, in-place upgrade.
+#
+#   ./upgrade.sh            upgrade to the latest version (backs up first)
+#   ./upgrade.sh --check    show current vs latest release; make NO changes
+#   ./upgrade.sh <ref>      upgrade to a specific tag or branch (e.g. v0.4.0)
+#
+# It ALWAYS backs up the database + .env before touching anything, applies new
+# migrations (additive by design), health-checks the new stack, and rolls back
+# automatically if it does not come up. Safe to run on a production instance.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+bold() { printf '\033[1m%s\033[0m\n' "$*"; }
+info() { printf '  \033[36m›\033[0m %s\n' "$*"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+warn() { printf '  \033[33m! %s\033[0m\n' "$*"; }
+die()  { printf '  \033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+[ -f docker-compose.yml ] && [ -d control-plane ] || \
+  die "run this from your sandboxd source dir (the folder with install.sh)."
+command -v git >/dev/null 2>&1 || die "git is required."
+
+# ── current + latest versions ────────────────────────────────────────
+CUR="$(git describe --tags --always 2>/dev/null || echo unknown)"
+LATEST="$(curl -fsSL https://api.github.com/repos/tastyeffectco/sandboxd/releases/latest 2>/dev/null \
+          | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1 || true)"
+[ -n "$LATEST" ] || LATEST="(couldn't reach GitHub)"
+
+bold "sandboxd upgrade"
+info "current release checkout : $CUR"
+info "latest release          : $LATEST"
+
+# ── --check: report and exit, changing nothing ───────────────────────
+if [ "${1:-}" = "--check" ]; then
+  case "$LATEST" in
+    "(couldn't reach GitHub)") warn "couldn't reach GitHub to check for the latest release." ;;
+    "$CUR")     ok "you're on the latest release ($LATEST)." ;;
+    *) case "$CUR" in
+         "$LATEST"-*) info "you're on a development build ahead of the latest release ($LATEST) — tracking main." ;;
+         *)           warn "an update may be available: $LATEST. Run ./upgrade.sh to install it." ;;
+       esac ;;
+  esac
+  exit 0
+fi
+
+REF="${1:-main}"   # default: track main (where releases land today); or pass a tag
+
+# ── load .env + detect docker/compose (mirrors install.sh) ───────────
+# shellcheck disable=SC1091
+set -a; . ./.env 2>/dev/null || true; set +a
+DATA_DIR="${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}"
+API_BIND="${SANDBOXD_API_BIND:-127.0.0.1:9090}"
+
+DOCKER="docker"; docker info >/dev/null 2>&1 || DOCKER="sudo docker"
+if $DOCKER compose version >/dev/null 2>&1; then COMPOSE="$DOCKER compose"
+elif command -v docker-compose >/dev/null 2>&1; then COMPOSE="docker-compose"
+else die "Docker Compose not found."; fi
+# Keep the console running if it was running.
+PROFILE=""; $DOCKER ps --format '{{.Names}}' 2>/dev/null | grep -q 'sandboxd-console' && PROFILE="--profile console"
+
+# ── 1. back up (always, before anything changes) ─────────────────────
+TS="$(date +%Y%m%d-%H%M%S 2>/dev/null || echo backup)"
+BK="$DATA_DIR/backups/$TS"
+DB="$DATA_DIR/state/sandboxd.db"
+PREV_SHA="$(git rev-parse HEAD)"
+bold "1/4 · Backing up"
+( mkdir -p "$BK" 2>/dev/null || sudo mkdir -p "$BK" ) || die "could not create backup dir $BK"
+[ -f "$DB" ] && { cp "$DB" "$BK/" 2>/dev/null || sudo cp "$DB" "$BK/"; }
+cp .env "$BK/.env" 2>/dev/null || true
+printf '%s\n' "$PREV_SHA" > "$BK/previous-commit.txt" 2>/dev/null || \
+  { printf '%s\n' "$PREV_SHA" | sudo tee "$BK/previous-commit.txt" >/dev/null; }
+ok "backup at $BK (database + .env + current commit $PREV_SHA)"
+
+# ── 2. fetch the new code ────────────────────────────────────────────
+bold "2/4 · Fetching $REF"
+git fetch --depth 1 -q origin "$REF"
+git reset --hard -q FETCH_HEAD
+NEW_SHA="$(git rev-parse HEAD)"
+if [ "$NEW_SHA" = "$PREV_SHA" ]; then ok "already up to date — nothing to do."; exit 0; fi
+ok "updated source to $(git describe --tags --always 2>/dev/null || echo "$NEW_SHA")"
+
+# ── 3. rebuild + restart (migrations apply on control-plane boot) ────
+bold "3/4 · Building + restarting the stack"
+$COMPOSE $PROFILE build
+$COMPOSE $PROFILE up -d
+
+# ── 4. health-check; roll back automatically on failure ──────────────
+bold "4/4 · Health check"
+healthy=0
+for _ in $(seq 1 30); do
+  if curl -fsS "http://$API_BIND/healthz" 2>/dev/null | grep -q ok; then healthy=1; break; fi
+  sleep 2
+done
+
+if [ "$healthy" = "1" ]; then
+  echo
+  ok "sandboxd is healthy on $(git describe --tags --always 2>/dev/null || echo "$NEW_SHA") 🎉"
+  info "backup kept at $BK — delete it once you're happy."
+else
+  echo
+  warn "the new version did not become healthy — rolling back."
+  [ -f "$BK/sandboxd.db" ] && { cp "$BK/sandboxd.db" "$DB" 2>/dev/null || sudo cp "$BK/sandboxd.db" "$DB"; }
+  git reset --hard -q "$PREV_SHA"
+  $COMPOSE $PROFILE build >/dev/null 2>&1 || true
+  $COMPOSE $PROFILE up -d || true
+  die "rolled back to $PREV_SHA (database restored from $BK). Inspect logs: $COMPOSE logs sandboxd"
+fi


### PR DESCRIPTION
A production-safe `./upgrade.sh`: backs up the DB + .env first, rebuilds/restarts, health-checks, and **rolls back automatically** if the new version doesn't come up. `--check` shows current vs latest. Adds a `sandboxd version` subcommand and `docs/upgrading.md` (linked from README + install summary). Minimal by design for v0.x — the safety (backup + rollback) is the point; console banner / one-click / doctor are deferred.