### PR TITLE
Reliable agent tasks + OpenCode zero-friction free tier + per-agent default model

### DIFF
--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -405,7 +405,7 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
   // in Settings first instead of hitting a confusing failed run.
   useEffect(() => {
     let alive = true
-    api.listAgents()
+    api.getAgents()
       .then((list) => { if (alive) setAgentConnected(list.some((p) => p.id === agent && p.status === 'connected')) })
       .catch(() => { if (alive) setAgentConnected(null) })
     return () => { alive = false }

--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -399,10 +399,15 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
   const scrollRef = useRef<HTMLDivElement>(null)
   const sandboxRunning = sb?.status === 'running'
   const [agentConnected, setAgentConnected] = useState<boolean | null>(null)
+  // Block input only when the selected agent needs a credential and has none.
+  // opencode is exempt: it runs on a keyless free tier out of the box, so an
+  // un-connected opencode is still usable (we just show a free-tier note).
+  const inputBlocked = agentConnected === false && agent !== 'opencode'
 
-  // Is the selected agent actually connected? A task with no connected agent
-  // fails immediately with an auth error — gate the input so users connect one
-  // in Settings first instead of hitting a confusing failed run.
+  // Is the selected agent actually connected? For non-opencode agents a task with
+  // no connected agent fails immediately with an auth error — gate the input so
+  // users connect one in Settings first instead of hitting a confusing failed run.
+  // opencode always runs (free tier), so it's never blocked (see inputBlocked).
   useEffect(() => {
     let alive = true
     api.getAgents()
@@ -531,14 +536,19 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
         {resolved && <div style={{ ...mono, fontSize: 10.5, color: c.muted2 }}>▸ {resolved}</div>}
         {running && <div style={{ ...mono, fontSize: 11.5, color: c.muted2, animation: 'pulse 1.4s ease-in-out infinite' }}>▍ working…</div>}
       </div>
-      {agentConnected === false && (
+      {inputBlocked && (
         <div style={{ padding: '8px 12px', borderTop: `1px solid ${c.border}`, background: c.panel2, fontSize: 12, color: c.fg }} data-testid="agent-not-connected">
-          ⚠ No <b>{agent === 'claude-code' ? 'Claude Code' : agent === 'opencode' ? 'OpenCode' : agent}</b> agent connected — connect one in <b>Settings → AI Agents</b> to start building.
+          ⚠ No <b>{agent === 'claude-code' ? 'Claude Code' : agent}</b> agent connected — connect one in <b>Settings → AI Agents</b> to start building.
+        </div>
+      )}
+      {agent === 'opencode' && agentConnected === false && (
+        <div style={{ padding: '8px 12px', borderTop: `1px solid ${c.border}`, background: c.panel2, fontSize: 12, color: c.muted2 }} data-testid="opencode-free-tier">
+          Using the <b>OpenCode free tier</b> — no setup needed. Connect an API key in <b>Settings → AI Agents</b> for the full model catalog.
         </div>
       )}
       <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: `1px solid ${c.border}`, background: c.panel3 }}>
-        <textarea value={text} onChange={(e) => setText(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }} placeholder={agentConnected === false ? 'Connect an agent in Settings first' : sandboxRunning ? 'Message the agent…' : 'Start the sandbox to run tasks'} data-testid="task-prompt" rows={1} style={{ flex: 1, background: '#fff', border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 11px', color: c.fg, fontSize: 12.5, fontFamily: font.sans, resize: 'none' }} />
-        <Btn variant="primary" onClick={send} disabled={!sb || !sandboxRunning || running || agentConnected === false} data-testid="run-task">Send</Btn>
+        <textarea value={text} onChange={(e) => setText(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }} placeholder={inputBlocked ? 'Connect an agent in Settings first' : sandboxRunning ? 'Message the agent…' : 'Start the sandbox to run tasks'} data-testid="task-prompt" rows={1} style={{ flex: 1, background: '#fff', border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 11px', color: c.fg, fontSize: 12.5, fontFamily: font.sans, resize: 'none' }} />
+        <Btn variant="primary" onClick={send} disabled={!sb || !sandboxRunning || running || inputBlocked} data-testid="run-task">Send</Btn>
       </div>
     </Card>
   )

--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -395,10 +395,23 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
   const [resolved, setResolved] = useState('')
   const [reverting, setReverting] = useState<string | null>(null)
   const esRef = useRef<EventSource | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const sandboxRunning = sb?.status === 'running'
+  const [agentConnected, setAgentConnected] = useState<boolean | null>(null)
 
-  useEffect(() => () => esRef.current?.close(), [])
+  // Is the selected agent actually connected? A task with no connected agent
+  // fails immediately with an auth error — gate the input so users connect one
+  // in Settings first instead of hitting a confusing failed run.
+  useEffect(() => {
+    let alive = true
+    api.listAgents()
+      .then((list) => { if (alive) setAgentConnected(list.some((p) => p.id === agent && p.status === 'connected')) })
+      .catch(() => { if (alive) setAgentConnected(null) })
+    return () => { alive = false }
+  }, [agent, history.length])
+
+  useEffect(() => () => { esRef.current?.close(); if (pollRef.current) clearInterval(pollRef.current) }, [])
   useEffect(() => { if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight }, [history, live, running])
 
   const loadHistory = useCallback(async () => {
@@ -423,14 +436,34 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
     try {
       const t = await api.submitTask(sb.id, prompt, agent, model || undefined, cont)
       let agentText = ''
+      let settled = false
+      const finish = async () => {
+        if (settled) return
+        settled = true
+        if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+        try { esRef.current?.close() } catch { /* */ }
+        setRunning(false); refresh(); await reloadUntil(t.id); setLive(null)
+      }
       const es = new EventSource(api.taskEventsURL(sb.id, t.id))
       esRef.current = es
       es.addEventListener('status', (m) => { try { const j = JSON.parse((m as MessageEvent).data); if (j.model) setResolved(j.model) } catch { /* */ } })
       es.addEventListener('message', (m) => {
         try { const j = JSON.parse((m as MessageEvent).data); if (j.role === 'agent' && j.text) { agentText += j.text; setLive((l) => (l ? { ...l, text: agentText } : l)) } } catch { /* */ }
       })
-      es.addEventListener('done', async () => { es.close(); setRunning(false); refresh(); await reloadUntil(t.id); setLive(null) })
-      es.onerror = () => { es.close(); setRunning(false); setLive(null); loadHistory() }
+      es.addEventListener('done', () => { finish() })
+      es.onerror = () => { try { es.close() } catch { /* */ } } // stream hiccup — the poll below still resolves it
+      // Reliability: never trust the SSE stream alone. A dropped or raced event
+      // stream must not leave the chat spinning — poll the task status until it
+      // reports terminal, with a watchdog cap so nothing can hang indefinitely.
+      let ticks = 0
+      pollRef.current = setInterval(async () => {
+        ticks++
+        try {
+          const cur = (await api.listTasks(sb.id)).find((x) => x.id === t.id)
+          if (cur && ['succeeded', 'failed', 'cancelled', 'error'].includes(cur.status)) { finish(); return }
+        } catch { /* */ }
+        if (ticks >= 360) finish() // ~15 min hard cap
+      }, 2500)
     } catch (e) { setRunning(false); setLive(null); onError((e as Error).message) }
   }
 
@@ -478,7 +511,7 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
           return (
             <Fragment key={t.id}>
               {t.prompt && bubble('user', t.prompt)}
-              {bubble('agent', t.agent_message || `(${t.status})`)}
+              {bubble('agent', t.agent_message || t.error_message || `(${t.status})`)}
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, paddingLeft: 2, fontSize: 11, color: c.muted2 }}>
                 <span style={{ ...mono, fontWeight: 700, color: tone(t.status), textTransform: 'uppercase' }}>{t.status}</span>
                 {files.length > 0 && <span title={files.join('\n')}>{files.length} file{files.length === 1 ? '' : 's'} changed</span>}
@@ -498,9 +531,14 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
         {resolved && <div style={{ ...mono, fontSize: 10.5, color: c.muted2 }}>▸ {resolved}</div>}
         {running && <div style={{ ...mono, fontSize: 11.5, color: c.muted2, animation: 'pulse 1.4s ease-in-out infinite' }}>▍ working…</div>}
       </div>
+      {agentConnected === false && (
+        <div style={{ padding: '8px 12px', borderTop: `1px solid ${c.border}`, background: c.panel2, fontSize: 12, color: c.fg }} data-testid="agent-not-connected">
+          ⚠ No <b>{agent === 'claude-code' ? 'Claude Code' : agent === 'opencode' ? 'OpenCode' : agent}</b> agent connected — connect one in <b>Settings → AI Agents</b> to start building.
+        </div>
+      )}
       <div style={{ display: 'flex', gap: 8, padding: 10, borderTop: `1px solid ${c.border}`, background: c.panel3 }}>
-        <textarea value={text} onChange={(e) => setText(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }} placeholder={sandboxRunning ? 'Message the agent…' : 'Start the sandbox to run tasks'} data-testid="task-prompt" rows={1} style={{ flex: 1, background: '#fff', border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 11px', color: c.fg, fontSize: 12.5, fontFamily: font.sans, resize: 'none' }} />
-        <Btn variant="primary" onClick={send} disabled={!sb || !sandboxRunning || running} data-testid="run-task">Send</Btn>
+        <textarea value={text} onChange={(e) => setText(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }} placeholder={agentConnected === false ? 'Connect an agent in Settings first' : sandboxRunning ? 'Message the agent…' : 'Start the sandbox to run tasks'} data-testid="task-prompt" rows={1} style={{ flex: 1, background: '#fff', border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 11px', color: c.fg, fontSize: 12.5, fontFamily: font.sans, resize: 'none' }} />
+        <Btn variant="primary" onClick={send} disabled={!sb || !sandboxRunning || running || agentConnected === false} data-testid="run-task">Send</Btn>
       </div>
     </Card>
   )

--- a/console/src/SettingsView.tsx
+++ b/console/src/SettingsView.tsx
@@ -50,17 +50,19 @@ export function SettingsView({ onError, toast }: { onError: (m: string) => void;
   const [keys, setKeys] = useState<ApiKey[]>([])
   const [keyName, setKeyName] = useState('')
   const [newKey, setNewKey] = useState('')
+  const [models, setModels] = useState<Record<string, string>>({})
 
   const loadAgents = useCallback(() => api.getAgents().then(setAgents).catch(() => {}), [])
   const loadCreds = useCallback(() => api.listGitCredentials().then(setCreds).catch(() => {}), [])
   const loadKeys = useCallback(() => api.listApiKeys().then(setKeys).catch(() => {}), [])
   useEffect(() => {
-    api.getSettings().then((d) => { setS(d); setIdle(d.lifecycle.idle_reap_enabled); setIdleSec(d.lifecycle.idle_threshold_seconds); setKeepSec(d.lifecycle.keepalive_max_seconds) }).catch((e) => onError((e as Error).message))
+    api.getSettings().then((d) => { setS(d); setIdle(d.lifecycle.idle_reap_enabled); setIdleSec(d.lifecycle.idle_threshold_seconds); setKeepSec(d.lifecycle.keepalive_max_seconds); setModels(d.agents.default_models || {}) }).catch((e) => onError((e as Error).message))
     loadAgents(); loadCreds(); loadKeys()
   }, [onError, loadAgents, loadCreds, loadKeys])
 
   if (!s) return <div style={{ padding: 40, color: c.muted2 }}>Loading…</div>
   const lifecycleEditable = (s.editable || []).some((p) => p.startsWith('lifecycle.'))
+  const modelsEditable = (s.editable || []).some((p) => p === 'agents.default_models')
 
   const connectClaude = async () => {
     try { const r = await api.oauthStart('claude-code'); window.open(r.authorize_url, '_blank'); const code = window.prompt('Approve in the opened tab, then paste the code here:'); if (code) { await api.oauthFinish('claude-code', code.trim()); toast('Claude connected'); loadAgents() } } catch (e) { onError((e as Error).message) }
@@ -68,6 +70,7 @@ export function SettingsView({ onError, toast }: { onError: (m: string) => void;
   const apiKey = async (id: string) => { const key = window.prompt(`Paste the ${id} API key:`); if (key) try { await api.setAgentApiKey(id, key.trim()); toast('Connected'); loadAgents() } catch (e) { onError((e as Error).message) } }
   const importCred = async (id: string) => { const v = window.prompt(`Paste the credential (from your ${id} login):`); if (v) try { await api.importAgentCredential(id, v); toast('Connected'); loadAgents() } catch (e) { onError((e as Error).message) } }
   const saveLifecycle = async () => { try { await api.patchSettings({ lifecycle: { idle_reap_enabled: idle, idle_threshold_seconds: idleSec, keepalive_max_seconds: keepSec } }); toast('Lifecycle saved') } catch (e) { onError((e as Error).message) } }
+  const saveModels = async () => { try { const d = await api.patchSettings({ agents: { default_models: models } }); setModels(d.agents.default_models || {}); toast('Default models saved') } catch (e) { onError((e as Error).message) } }
   const addCred = async () => { if (!gc.name || !gc.host || !gc.token) return; try { await api.createGitCredential(gc); setGc({ name: '', host: '', username: '', token: '' }); toast('Credential added'); loadCreds() } catch (e) { onError((e as Error).message) } }
   const changePw = async () => { if (!curPw || !newPw) return; try { await api.changePassword({ current_password: curPw, new_password: newPw }); setCurPw(''); setNewPw(''); toast('Password changed') } catch (e) { onError((e as Error).message) } }
   const signOutEverywhere = async () => { try { await api.logoutEverywhere(); location.reload() } catch (e) { onError((e as Error).message) } }
@@ -122,7 +125,28 @@ export function SettingsView({ onError, toast }: { onError: (m: string) => void;
             </div>
           )})}
         </div>
-        <div style={{ color: c.muted2, fontSize: 12, lineHeight: 1.5 }}>Each agent runs on your own account; credentials are stored opaquely server-side, never shown in the browser, and kept out of snapshots. <b style={{ color: c.fg2 }}>Claude Code</b> subscriptions run through a credential-injecting proxy — the token never enters the sandbox. <b style={{ color: c.fg2 }}>Codex is disabled for now</b>: its ChatGPT-subscription auth uses a WebSocket backend that can't yet be put behind that proxy, and we won't mount a raw token into the sandbox.</div>
+
+        {/* Optional per-agent default model. The user supplies the real provider
+            model id; it's used when a task doesn't pick one. */}
+        <div style={{ marginTop: 14, paddingTop: 12, borderTop: `1px solid ${c.border}` }} data-testid="settings-agent-models">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+            <H style={{ fontSize: 13 }}>Default model</H>
+            <Src kind={modelsEditable ? 'editable' : undefined} env={modelsEditable ? undefined : 'SANDBOXD_OPENCODE_MODEL'} />
+            <span style={{ marginLeft: 'auto', fontSize: 11.5, color: c.muted2 }}>optional — used when a task doesn't pick a model</span>
+          </div>
+          <div style={{ color: c.muted2, fontSize: 12, lineHeight: 1.5, marginBottom: 10 }}>Paste each agent's own model id (e.g. OpenCode <span style={{ ...mono, fontSize: 11 }}>glm-5</span>, Claude <span style={{ ...mono, fontSize: 11 }}>sonnet</span>). Leave blank for the agent's default — OpenCode with no API key falls back to its free tier (<span style={{ ...mono, fontSize: 11 }}>big-pickle</span>).</div>
+          {agents.filter((a) => a.id !== 'codex').map((a) => (
+            <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+              <span style={{ width: 130, fontSize: 12.5, color: c.muted }}>{a.label}</span>
+              <Input mono value={models[a.id] || ''} onChange={(e) => setModels({ ...models, [a.id]: e.target.value })} disabled={!modelsEditable} placeholder={a.id === 'opencode' ? 'big-pickle (free tier)' : 'agent default'} style={{ width: 260 }} data-testid={`agent-model-${a.id}`} />
+            </div>
+          ))}
+          {modelsEditable
+            ? <Btn onClick={saveModels} style={{ marginTop: 8 }} data-testid="save-agent-models">Save default models</Btn>
+            : <div style={{ marginTop: 8, fontSize: 12, color: c.muted2 }}>Read-only on this instance — set <span style={{ ...mono, fontSize: 11 }}>SANDBOXD_OPENCODE_MODEL</span> (opencode) or per-task model.</div>}
+        </div>
+
+        <div style={{ color: c.muted2, fontSize: 12, lineHeight: 1.5, marginTop: 14 }}>Each agent runs on your own account; credentials are stored opaquely server-side, never shown in the browser, and kept out of snapshots. <b style={{ color: c.fg2 }}>OpenCode</b> works out of the box with <b style={{ color: c.fg2 }}>no key</b> on its free tier — add an API key for the full model catalog. <b style={{ color: c.fg2 }}>Claude Code</b> subscriptions run through a credential-injecting proxy — the token never enters the sandbox. <b style={{ color: c.fg2 }}>Codex is disabled for now</b>: its ChatGPT-subscription auth uses a WebSocket backend that can't yet be put behind that proxy, and we won't mount a raw token into the sandbox.</div>
       </Card>
 
       <Card style={{ padding: 16, marginBottom: 12 }} data-testid="settings-lifecycle">

--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -127,6 +127,7 @@ export interface TaskSummary {
   agent?: string
   status: string
   agent_message?: string
+  error_message?: string
   files_changed?: string[]
   checkpoint_id?: string
   can_revert: boolean

--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -38,7 +38,7 @@ export interface Settings {
   runtime: { storage_mode: string; base_image: string }
   lifecycle: { idle_reap_enabled: boolean; idle_threshold_seconds: number; keepalive_max_seconds: number }
   egress: { mode: string }
-  agents: { providers: string[]; system_prompt?: string }
+  agents: { providers: string[]; system_prompt?: string; default_models: Record<string, string> }
   presets: Preset[]
   capabilities: Record<string, boolean>
   editable?: string[] // field paths the client may PATCH (e.g. lifecycle.*)
@@ -65,6 +65,8 @@ export interface SettingsPatch {
     idle_threshold_seconds?: number
     keepalive_max_seconds?: number
   }
+  // Per-agent default model id (merges; empty value clears one).
+  agents?: { default_models?: Record<string, string> }
 }
 
 // Advisory runtime detection (GET /v1/apps/{id}/runtime-inspect). Suggestions

--- a/console/src/test/fixtures.ts
+++ b/console/src/test/fixtures.ts
@@ -81,10 +81,10 @@ export const settingsFixture: Settings = {
   runtime: { storage_mode: 'directory', base_image: 'sandboxd-base:1.0.0' },
   lifecycle: { idle_reap_enabled: true, idle_threshold_seconds: 2100, keepalive_max_seconds: 86400 },
   egress: { mode: 'disabled' },
-  agents: { providers: ['opencode'] },
+  agents: { providers: ['opencode'], default_models: {} },
   presets: presetsFixture,
   capabilities: { snapshots: true, config_secrets: true, templates: false, forward_auth: true },
-  editable: ['lifecycle.idle_reap_enabled', 'lifecycle.idle_threshold_seconds', 'lifecycle.keepalive_max_seconds'],
+  editable: ['lifecycle.idle_reap_enabled', 'lifecycle.idle_threshold_seconds', 'lifecycle.keepalive_max_seconds', 'agents.default_models'],
 }
 
 // --- fetch mock ------------------------------------------------------

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -305,8 +305,9 @@ func main() {
 			IdleEnabled:          persisted.IdleReapEnabled,
 			IdleThresholdSeconds: persisted.IdleThresholdSeconds,
 			KeepaliveMaxSeconds:  persisted.KeepaliveMaxSeconds,
+			DefaultModels:        persisted.AgentDefaultModels,
 		})
-		log.Info("instance settings: loaded persisted lifecycle tunables")
+		log.Info("instance settings: loaded persisted lifecycle tunables + agent default models")
 	}
 
 	inflight := activity.NewInflightExec()

--- a/control-plane/internal/api/v1_settings.go
+++ b/control-plane/internal/api/v1_settings.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/agentauth"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/agentprompt"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/audit"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/preset"
@@ -80,6 +82,9 @@ type v1SettingsAgents struct {
 	// only). Rendered with default port/health for display; runtimed renders it
 	// with each sandbox's real values at task time. Single source: internal/agentprompt.
 	SystemPrompt string `json:"system_prompt,omitempty"`
+	// DefaultModels maps an agent id to its operator-set default model id, used
+	// when a task doesn't specify one. Editable via PATCH. Empty map when unset.
+	DefaultModels map[string]string `json:"default_models"`
 }
 
 // v1GetSettings — GET /v1/settings. Read-only, tokenless-safe instance summary.
@@ -114,7 +119,7 @@ func (s *Server) v1GetSettings(w http.ResponseWriter, _ *http.Request) {
 		Runtime:   v1SettingsRuntime{StorageMode: storageMode, BaseImage: s.Image},
 		Lifecycle: s.lifecycleView(),
 		Egress:    v1SettingsEgress{Mode: egressMode},
-		Agents:    v1SettingsAgents{Providers: s.Instance.AgentProviders, SystemPrompt: agentprompt.Render(agentprompt.Vars{})},
+		Agents:    v1SettingsAgents{Providers: s.Instance.AgentProviders, SystemPrompt: agentprompt.Render(agentprompt.Vars{}), DefaultModels: s.agentDefaultModels()},
 		Presets:   presets,
 		Capabilities: map[string]bool{
 			"snapshots":      s.Snapshot != nil,
@@ -128,6 +133,7 @@ func (s *Server) v1GetSettings(w http.ResponseWriter, _ *http.Request) {
 			"lifecycle.idle_reap_enabled",
 			"lifecycle.idle_threshold_seconds",
 			"lifecycle.keepalive_max_seconds",
+			"agents.default_models",
 		}
 	}
 	if s.Update != nil {
@@ -179,7 +185,15 @@ type v1SettingsPatch struct {
 		IdleThresholdSeconds *int  `json:"idle_threshold_seconds"`
 		KeepaliveMaxSeconds  *int  `json:"keepalive_max_seconds"`
 	} `json:"lifecycle"`
+	Agents *struct {
+		// DefaultModels merges into the stored map: a non-empty value sets that
+		// agent's default model, an empty value clears it. Other agents untouched.
+		DefaultModels map[string]string `json:"default_models"`
+	} `json:"agents"`
 }
+
+// maxAgentDefaultModels bounds how many per-agent defaults can be stored.
+const maxAgentDefaultModels = 32
 
 // v1PatchSettings — PATCH /v1/settings. Edits ONLY the lifecycle tunables; it
 // persists them, hot-applies via the shared Live config, and audits the change.
@@ -194,46 +208,90 @@ func (s *Server) v1PatchSettings(w http.ResponseWriter, r *http.Request) {
 	var req v1SettingsPatch
 	if err := dec.Decode(&req); err != nil {
 		writeV1Err(w, http.StatusBadRequest, "invalid_request",
-			"only lifecycle tunables are editable (idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds): "+err.Error())
+			"editable: lifecycle tunables (idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds) and agents.default_models: "+err.Error())
 		return
 	}
-	if req.Lifecycle == nil {
+	if req.Lifecycle == nil && req.Agents == nil {
 		writeV1Err(w, http.StatusBadRequest, "invalid_request", "no editable fields provided")
 		return
 	}
 
 	next := s.Live.Snapshot()
-	if v := req.Lifecycle.IdleReapEnabled; v != nil {
-		next.IdleEnabled = *v
+	target := "settings"
+	if req.Lifecycle != nil {
+		target = "lifecycle"
+		if v := req.Lifecycle.IdleReapEnabled; v != nil {
+			next.IdleEnabled = *v
+		}
+		if v := req.Lifecycle.IdleThresholdSeconds; v != nil {
+			next.IdleThresholdSeconds = *v
+		}
+		if v := req.Lifecycle.KeepaliveMaxSeconds; v != nil {
+			next.KeepaliveMaxSeconds = *v
+		}
+		if next.IdleThresholdSeconds < minIdleThresholdSec || next.IdleThresholdSeconds > maxIdleThresholdSec {
+			writeV1Err(w, http.StatusBadRequest, "invalid_request",
+				fmt.Sprintf("idle_threshold_seconds must be %d..%d", minIdleThresholdSec, maxIdleThresholdSec))
+			return
+		}
+		if next.KeepaliveMaxSeconds < 0 || next.KeepaliveMaxSeconds > maxKeepaliveSec {
+			writeV1Err(w, http.StatusBadRequest, "invalid_request",
+				fmt.Sprintf("keepalive_max_seconds must be 0..%d", maxKeepaliveSec))
+			return
+		}
 	}
-	if v := req.Lifecycle.IdleThresholdSeconds; v != nil {
-		next.IdleThresholdSeconds = *v
-	}
-	if v := req.Lifecycle.KeepaliveMaxSeconds; v != nil {
-		next.KeepaliveMaxSeconds = *v
-	}
-	if next.IdleThresholdSeconds < minIdleThresholdSec || next.IdleThresholdSeconds > maxIdleThresholdSec {
-		writeV1Err(w, http.StatusBadRequest, "invalid_request",
-			fmt.Sprintf("idle_threshold_seconds must be %d..%d", minIdleThresholdSec, maxIdleThresholdSec))
-		return
-	}
-	if next.KeepaliveMaxSeconds < 0 || next.KeepaliveMaxSeconds > maxKeepaliveSec {
-		writeV1Err(w, http.StatusBadRequest, "invalid_request",
-			fmt.Sprintf("keepalive_max_seconds must be 0..%d", maxKeepaliveSec))
-		return
+	if req.Agents != nil && req.Agents.DefaultModels != nil {
+		target = "agents.default_models"
+		merged := map[string]string{}
+		for k, v := range next.DefaultModels {
+			merged[k] = v
+		}
+		for agent, model := range req.Agents.DefaultModels {
+			if !agentauth.Runnable(agent) {
+				writeV1Err(w, http.StatusBadRequest, "invalid_request",
+					"unknown agent in default_models: "+agent)
+				return
+			}
+			if len(model) > 200 {
+				writeV1Err(w, http.StatusBadRequest, "invalid_request", "model too long for agent "+agent)
+				return
+			}
+			if strings.TrimSpace(model) == "" {
+				delete(merged, agent) // empty clears the default
+			} else {
+				merged[agent] = strings.TrimSpace(model)
+			}
+		}
+		if len(merged) > maxAgentDefaultModels {
+			writeV1Err(w, http.StatusBadRequest, "invalid_request",
+				fmt.Sprintf("too many agent default models (max %d)", maxAgentDefaultModels))
+			return
+		}
+		next.DefaultModels = merged
 	}
 
 	if err := s.Store.SaveInstanceSettings(r.Context(), store.InstanceSettings{
 		IdleReapEnabled:      next.IdleEnabled,
 		IdleThresholdSeconds: next.IdleThresholdSeconds,
 		KeepaliveMaxSeconds:  next.KeepaliveMaxSeconds,
+		AgentDefaultModels:   next.DefaultModels,
 	}); err != nil {
 		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	s.Live.Set(next) // hot-apply (reaper + keepalive read this live)
-	s.auditAction(r, audit.Entry{Action: "settings.update", Target: "lifecycle"})
+	s.Live.Set(next) // hot-apply (reaper + keepalive + task-submit read this live)
+	s.auditAction(r, audit.Entry{Action: "settings.update", Target: target})
 	s.v1GetSettings(w, r) // echo the updated settings
+}
+
+// agentDefaultModels returns the live per-agent default model map (never nil).
+func (s *Server) agentDefaultModels() map[string]string {
+	if s.Live != nil {
+		if m := s.Live.Snapshot().DefaultModels; m != nil {
+			return m
+		}
+	}
+	return map[string]string{}
 }
 
 // previewBase is the scheme://host[:port] previews are reached under, with the

--- a/control-plane/internal/api/v1_settings_patch_test.go
+++ b/control-plane/internal/api/v1_settings_patch_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -57,7 +58,7 @@ func TestPatchSettingsRejectsProtectedKeys(t *testing.T) {
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("body %s: got %d, want 400", body, w.Code)
 		}
-		if s.Live.Snapshot() != before {
+		if !reflect.DeepEqual(s.Live.Snapshot(), before) {
 			t.Errorf("body %s mutated live settings", body)
 		}
 		if got, _ := s.Store.GetInstanceSettings(context.Background()); got != nil {
@@ -107,6 +108,70 @@ func TestPatchSettingsPersistsAndHotApplies(t *testing.T) {
 	}
 	if len(resp["editable"].([]any)) == 0 {
 		t.Error("editable list should be present")
+	}
+}
+
+// Per-agent default models: a valid PATCH merges, persists, hot-applies, and
+// echoes; an empty value clears one; other agents are preserved.
+func TestPatchAgentDefaultModels(t *testing.T) {
+	s := newSettingsServer(t)
+
+	// Set two defaults.
+	w := patchSettings(s, `{"agents":{"default_models":{"opencode":"glm-5","claude-code":"sonnet"}}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("set: got %d: %s", w.Code, w.Body)
+	}
+	if got := s.Live.DefaultModel("opencode"); got != "glm-5" {
+		t.Errorf("live opencode = %q; want glm-5", got)
+	}
+	p, _ := s.Store.GetInstanceSettings(context.Background())
+	if p == nil || p.AgentDefaultModels["claude-code"] != "sonnet" {
+		t.Errorf("not persisted: %+v", p)
+	}
+
+	// Merge: change opencode, leave claude-code untouched.
+	w = patchSettings(s, `{"agents":{"default_models":{"opencode":"grok-4.5"}}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("merge: got %d: %s", w.Code, w.Body)
+	}
+	if s.Live.DefaultModel("opencode") != "grok-4.5" || s.Live.DefaultModel("claude-code") != "sonnet" {
+		t.Errorf("merge did not preserve others: %+v", s.Live.Snapshot().DefaultModels)
+	}
+
+	// Empty value clears a default.
+	w = patchSettings(s, `{"agents":{"default_models":{"opencode":""}}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear: got %d: %s", w.Code, w.Body)
+	}
+	if s.Live.DefaultModel("opencode") != "" {
+		t.Errorf("opencode default not cleared: %q", s.Live.DefaultModel("opencode"))
+	}
+	if s.Live.DefaultModel("claude-code") != "sonnet" {
+		t.Errorf("clear wiped an unrelated agent")
+	}
+
+	// Echo surfaces the map.
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if _, ok := resp["agents"].(map[string]any)["default_models"]; !ok {
+		t.Error("echo missing agents.default_models")
+	}
+}
+
+// Unknown agents and over-long model ids are rejected; lifecycle preserved.
+func TestPatchAgentDefaultModelsValidation(t *testing.T) {
+	s := newSettingsServer(t)
+	long := `{"agents":{"default_models":{"opencode":"` + strings.Repeat("x", 201) + `"}}}`
+	for _, body := range []string{
+		`{"agents":{"default_models":{"bogus-agent":"x"}}}`, // not runnable
+		long,
+	} {
+		if w := patchSettings(s, body); w.Code != http.StatusBadRequest {
+			t.Errorf("body %s: got %d, want 400", body, w.Code)
+		}
+	}
+	if got := s.Live.DefaultModel("opencode"); got != "" {
+		t.Errorf("rejected patches must not persist: %q", got)
 	}
 }
 

--- a/control-plane/internal/api/v1_tasks.go
+++ b/control-plane/internal/api/v1_tasks.go
@@ -211,6 +211,7 @@ type v1TaskSummary struct {
 	Agent        string   `json:"agent,omitempty"`
 	Status       string   `json:"status"`
 	AgentMessage string   `json:"agent_message,omitempty"` // the agent's final reply, for the chat history
+	ErrorMessage string   `json:"error_message,omitempty"` // why a task failed (e.g. agent not connected) — surfaced to the user
 	FilesChanged []string `json:"files_changed,omitempty"`
 	CheckpointID string   `json:"checkpoint_id,omitempty"`
 	CanRevert    bool     `json:"can_revert"` // a checkpoint exists to go back to
@@ -234,6 +235,12 @@ func (s *Server) v1ListTasks(w http.ResponseWriter, r *http.Request) {
 			var tr runtime.TaskResult
 			if json.Unmarshal([]byte(t.ResultJSON.String), &tr) == nil {
 				sum.AgentMessage = tr.AgentMessageFinal
+				sum.ErrorMessage = tr.ErrorMessage
+				// A failed task (esp. opencode) can finish with no agent reply —
+				// fall back to the error so the chat never shows a blank "(failed)".
+				if sum.AgentMessage == "" {
+					sum.AgentMessage = tr.ErrorMessage
+				}
 				sum.FilesChanged = tr.FilesChanged
 				sum.CheckpointID = tr.CheckpointID
 				sum.CanRevert = tr.CheckpointID != ""

--- a/control-plane/internal/api/v1_tasks.go
+++ b/control-plane/internal/api/v1_tasks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -20,6 +21,20 @@ import (
 func (s *Server) runtimeClientFor(id string) *runtime.Client {
 	_, mnt := s.Loopback.Paths(id)
 	return runtime.NewClient(filepath.Join(mnt, ".runtimed", "sock"))
+}
+
+// defaultOpencodeFreeModel is the keyless Zen model an un-connected opencode
+// task falls back to. It must be one of Zen's free (no-auth) models — "big-pickle"
+// is opencode's featured free model. Override with SANDBOXD_OPENCODE_FREE_MODEL.
+const defaultOpencodeFreeModel = "big-pickle"
+
+// opencodeFreeModel is the model used when opencode runs with no connected
+// credential (its zero-friction free tier). Operator-overridable.
+func opencodeFreeModel() string {
+	if m := os.Getenv("SANDBOXD_OPENCODE_FREE_MODEL"); m != "" {
+		return m
+	}
+	return defaultOpencodeFreeModel
 }
 
 // --- POST /v1/sandboxes/{id}/tasks ----------------------------------
@@ -116,6 +131,24 @@ func (s *Server) v1SubmitTask(w http.ResponseWriter, r *http.Request) {
 	if len(req.Model) > 200 {
 		writeV1Err(w, http.StatusBadRequest, "invalid_request", "model too long")
 		return
+	}
+
+	// Model precedence when the caller didn't pick one (req.Model == ""):
+	//   1. the operator's per-agent default model (Settings → AI Agents), then
+	//   2. opencode's zero-friction free tier (only when nothing is connected).
+	// An explicit per-task model always wins over both. Downstream, runtimed adds
+	// its own env/agent-default fallback (RUNTIMED_OPENCODE_MODEL). See docs/agent-auth.md.
+	if req.Model == "" && s.Live != nil {
+		req.Model = s.Live.DefaultModel(agent) // "" when unset
+	}
+	// OpenCode zero-friction free tier: when opencode has no connected credential
+	// and still no model, default to a keyless free Zen model so a fresh install
+	// can build with no setup at all. A connected key/subscription (handled in the
+	// proxy) or any chosen model takes precedence and uses the full catalog. Only
+	// opencode has a free tier — other agents still need to be connected first.
+	if agent == "opencode" && req.Model == "" &&
+		(s.AgentAuth == nil || !s.AgentAuth.Connected("opencode")) {
+		req.Model = opencodeFreeModel()
 	}
 
 	taskID := newULID()

--- a/control-plane/internal/authproxy/proxy.go
+++ b/control-plane/internal/authproxy/proxy.go
@@ -144,6 +144,19 @@ func (p *Proxy) credFor(agent, up string) (func(http.Header), bool) {
 			}, true
 		}
 	}
+	// OpenCode zero-friction free tier: with no connected credential, opencode
+	// still works out of the box on Zen's keyless free models. We forward with NO
+	// auth (dropping the sandbox's dummy key) — the free models need none. This is
+	// opencode-only; every other agent still requires a connected credential, so
+	// they keep returning ok=false (a clear "connect it" 401). A connected key or
+	// subscription is handled by the api_key/oauth cases above and takes over the
+	// full paid catalog — this branch is reached only when nothing is connected.
+	if agent == "opencode" {
+		return func(h http.Header) {
+			h.Del("Authorization")
+			h.Del("X-Api-Key")
+		}, true
+	}
 	return nil, false
 }
 

--- a/control-plane/internal/authproxy/proxy_test.go
+++ b/control-plane/internal/authproxy/proxy_test.go
@@ -146,3 +146,47 @@ func TestInjectsAnthropicAPIKeyHeader(t *testing.T) {
 		t.Errorf("X-Api-Key = %q; want the injected key", gotKey)
 	}
 }
+
+// opencode with NO connected credential falls back to Zen's keyless free tier:
+// the proxy forwards to the zen upstream with NO auth (the sandbox's dummy key
+// stripped), rather than returning 401. This is what makes opencode work out of
+// the box with zero setup. It is opencode-only — every other agent still 401s
+// when unconnected (see TestServeNoCredential).
+func TestOpencodeFreeTierKeyless(t *testing.T) {
+	var gotAuth, gotKey, gotPath string
+	forwarded := false
+	stubUpstream(t, "zen", func(w http.ResponseWriter, r *http.Request) {
+		forwarded = true
+		gotAuth, gotKey, gotPath = r.Header.Get("Authorization"), r.Header.Get("X-Api-Key"), r.URL.Path
+		w.WriteHeader(200)
+	})
+	p := New(agentauth.NewStore(t.TempDir()), nil) // nothing connected
+
+	req := httptest.NewRequest("POST", "/opencode/zen/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sandboxd-proxy-injected") // the dummy the sandbox sends
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if !forwarded {
+		t.Fatalf("expected keyless forward to zen; got status %d (want 200 forward)", w.Code)
+	}
+	if gotAuth != "" {
+		t.Errorf("Authorization leaked to upstream: %q (free tier must send none)", gotAuth)
+	}
+	if gotKey != "" {
+		t.Errorf("X-Api-Key leaked to upstream: %q (dummy must be stripped)", gotKey)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("forwarded path = %q; want /v1/chat/completions", gotPath)
+	}
+}
+
+// A NON-opencode agent with no credential still returns 401 (no keyless tier).
+func TestCodexNoCredentialStill401(t *testing.T) {
+	p := New(agentauth.NewStore(t.TempDir()), nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, httptest.NewRequest("POST", "/codex/openai/v1/chat/completions", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("codex unconnected = %d; want 401 (only opencode has a free tier)", w.Code)
+	}
+}

--- a/control-plane/internal/instancecfg/live.go
+++ b/control-plane/internal/instancecfg/live.go
@@ -9,11 +9,14 @@ import (
 	"time"
 )
 
-// Snapshot is a plain copy of the editable lifecycle settings.
+// Snapshot is a plain copy of the editable lifecycle settings plus the per-agent
+// default models. DefaultModels is treated as immutable once stored — readers must
+// not mutate it; writers pass a fresh map (Set/New clone it defensively).
 type Snapshot struct {
 	IdleEnabled          bool
 	IdleThresholdSeconds int
 	KeepaliveMaxSeconds  int
+	DefaultModels        map[string]string // agent id -> default model id
 }
 
 // Live is the shared, mutable holder. Construct with New; read via the
@@ -23,7 +26,7 @@ type Live struct {
 	snap Snapshot
 }
 
-func New(s Snapshot) *Live { return &Live{snap: s} }
+func New(s Snapshot) *Live { return &Live{snap: cloneSnap(s)} }
 
 func (l *Live) Snapshot() Snapshot {
 	l.mu.RLock()
@@ -34,7 +37,30 @@ func (l *Live) Snapshot() Snapshot {
 func (l *Live) Set(s Snapshot) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	l.snap = s
+	l.snap = cloneSnap(s)
+}
+
+// DefaultModel returns the configured default model id for an agent, or "" when
+// none is set. Hot-read at task submit.
+func (l *Live) DefaultModel(agent string) string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.snap.DefaultModels[agent]
+}
+
+// cloneSnap deep-copies the map so a stored Snapshot never shares mutable state
+// with the caller (Set and New both clone; readers get the stored value).
+func cloneSnap(s Snapshot) Snapshot {
+	if s.DefaultModels == nil {
+		s.DefaultModels = map[string]string{}
+		return s
+	}
+	m := make(map[string]string, len(s.DefaultModels))
+	for k, v := range s.DefaultModels {
+		m[k] = v
+	}
+	s.DefaultModels = m
+	return s
 }
 
 // IdleEnabled reports whether the idle reaper should reap (hot-read each tick).

--- a/control-plane/internal/store/instance_settings.go
+++ b/control-plane/internal/store/instance_settings.go
@@ -3,27 +3,34 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"time"
 )
 
-// InstanceSettings is the persisted, runtime-editable lifecycle tuning (Phase
-// 8B). Only safe operational timers — never secrets.
+// InstanceSettings is the persisted, runtime-editable instance config: lifecycle
+// tuning (Phase 8B) plus per-agent default models. Only safe operational values —
+// never secrets.
 type InstanceSettings struct {
 	IdleReapEnabled      bool
 	IdleThresholdSeconds int
 	KeepaliveMaxSeconds  int
+	// AgentDefaultModels maps an agent id (e.g. "opencode") to the default model
+	// id used when a task doesn't specify one. Opaque, operator-supplied. Never nil
+	// on read (empty map when unset).
+	AgentDefaultModels map[string]string
 }
 
 // GetInstanceSettings returns the singleton row, or ErrNotFound if unset (the
 // caller then falls back to env defaults).
 func (s *Store) GetInstanceSettings(ctx context.Context) (*InstanceSettings, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds
+		`SELECT idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds, agent_default_models
 		   FROM instance_settings WHERE id = 1`)
 	var enabled int
+	var modelsJSON string
 	out := &InstanceSettings{}
-	err := row.Scan(&enabled, &out.IdleThresholdSeconds, &out.KeepaliveMaxSeconds)
+	err := row.Scan(&enabled, &out.IdleThresholdSeconds, &out.KeepaliveMaxSeconds, &modelsJSON)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -31,25 +38,39 @@ func (s *Store) GetInstanceSettings(ctx context.Context) (*InstanceSettings, err
 		return nil, err
 	}
 	out.IdleReapEnabled = enabled != 0
+	out.AgentDefaultModels = map[string]string{}
+	if modelsJSON != "" {
+		// Tolerate a malformed value rather than failing the whole read.
+		_ = json.Unmarshal([]byte(modelsJSON), &out.AgentDefaultModels)
+	}
 	return out, nil
 }
 
-// SaveInstanceSettings upserts the singleton row.
+// SaveInstanceSettings upserts the singleton row (all fields).
 func (s *Store) SaveInstanceSettings(ctx context.Context, v InstanceSettings) error {
 	return s.submit(ctx, func(db *sql.DB) error {
 		enabled := 0
 		if v.IdleReapEnabled {
 			enabled = 1
 		}
-		_, err := db.ExecContext(ctx, `
-			INSERT INTO instance_settings (id, idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds, updated_at)
-			VALUES (1, ?, ?, ?, ?)
+		models := v.AgentDefaultModels
+		if models == nil {
+			models = map[string]string{}
+		}
+		modelsJSON, err := json.Marshal(models)
+		if err != nil {
+			return err
+		}
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO instance_settings (id, idle_reap_enabled, idle_threshold_seconds, keepalive_max_seconds, agent_default_models, updated_at)
+			VALUES (1, ?, ?, ?, ?, ?)
 			ON CONFLICT(id) DO UPDATE SET
 			  idle_reap_enabled = excluded.idle_reap_enabled,
 			  idle_threshold_seconds = excluded.idle_threshold_seconds,
 			  keepalive_max_seconds = excluded.keepalive_max_seconds,
+			  agent_default_models = excluded.agent_default_models,
 			  updated_at = excluded.updated_at`,
-			enabled, v.IdleThresholdSeconds, v.KeepaliveMaxSeconds, time.Now().Unix())
+			enabled, v.IdleThresholdSeconds, v.KeepaliveMaxSeconds, string(modelsJSON), time.Now().Unix())
 		return err
 	})
 }

--- a/control-plane/migrations/0023_agent_default_models.sql
+++ b/control-plane/migrations/0023_agent_default_models.sql
@@ -1,0 +1,7 @@
+-- Per-agent default model id, set from the console (Settings → AI Agents) and
+-- used when a task doesn't specify a model. The user supplies the real provider
+-- model id (e.g. opencode "glm-5", claude "sonnet"); sandboxd stores it opaquely
+-- and passes it through as the agent CLI's --model. JSON object {agent: model_id}.
+-- Additive: existing rows default to '{}'. Non-secret — safe to show any operator.
+-- See internal/api/v1_tasks.go (model precedence) and v1_settings.go.
+ALTER TABLE instance_settings ADD COLUMN agent_default_models TEXT NOT NULL DEFAULT '{}';

--- a/docs/agent-auth.md
+++ b/docs/agent-auth.md
@@ -88,6 +88,37 @@ picked model isn't in that path's catalog (e.g. a `claude-*` model on `zengo`).
 The console's opencode model dropdown should list models from whichever path you
 set — go-subscription models (GLM/Kimi/…) for `zengo`.
 
+### OpenCode free tier — works with no key (zero friction)
+
+**opencode is usable out of the box with nothing connected.** Zen serves a set of
+free models (ids ending `-free`, e.g. `big-pickle`, `deepseek-v4-flash-free`,
+`mimo-v2.5-free`) that need **no API key**. When opencode has no connected
+credential, the proxy forwards its requests to Zen **keyless** — it drops the
+sandbox's dummy key and injects nothing — and the control plane defaults the
+task's model to a free one so a fresh install can build immediately.
+
+- **No key** → free tier. The default free model is `big-pickle`; override with
+  `SANDBOXD_OPENCODE_FREE_MODEL`.
+- **Key connected** (Settings → AI Agents) → the proxy injects it and opencode
+  gets the full paid catalog, exactly as before. A connected key always wins.
+
+This is **opencode-only** — it's the one provider with a keyless free tier. Every
+other agent (claude-code, codex) still returns a clear "connect it" error when
+unconnected. See `internal/authproxy/proxy.go` (`credFor`) and
+`internal/api/v1_tasks.go` (model precedence).
+
+### Per-agent default model (optional)
+
+Set a default model per agent in **Settings → AI Agents → Default model** (or via
+`PATCH /v1/settings` `agents.default_models`). You supply the agent's real model
+id (e.g. opencode `glm-5`, claude `sonnet`); it's used when a task doesn't specify
+one. Stored durably, applied live. Model precedence for a task:
+
+1. the task's own `model` (per request), then
+2. the per-agent default (this setting), then
+3. opencode's free-tier default (only when opencode has no key), then
+4. runtimed's env/agent default (`SANDBOXD_OPENCODE_MODEL` / the CLI's own).
+
 ### Fallback: no proxy → mounted auth dir
 
 If the proxy is disabled, the connected provider's opaque auth dir

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,10 +36,11 @@ paths:
     patch:
       operationId: updateSettings
       tags: [apps]
-      summary: Edit the runtime-editable lifecycle tunables only (allowlisted)
+      summary: Edit the runtime-editable settings (allowlisted)
       description: >
-        Accepts ONLY lifecycle tunables. Any other key (auth, egress, networking,
-        secrets, version, …) is rejected with 400. Persisted and hot-applied.
+        Accepts ONLY the allowlisted editable fields: lifecycle tunables and
+        agents.default_models. Any other key (auth, egress, networking, secrets,
+        version, …) is rejected with 400. Persisted and hot-applied.
       requestBody:
         required: true
         content:
@@ -53,6 +54,16 @@ paths:
                     idle_reap_enabled: { type: boolean }
                     idle_threshold_seconds: { type: integer }
                     keepalive_max_seconds: { type: integer }
+                agents:
+                  type: object
+                  properties:
+                    default_models:
+                      type: object
+                      additionalProperties: { type: string }
+                      description: >
+                        Per-agent default model id (agent -> model). Merges into the
+                        stored map; an empty value clears that agent's default. Only
+                        runnable agents are accepted.
       responses:
         "200":
           description: Updated settings.
@@ -1461,6 +1472,10 @@ components:
           properties:
             providers: { type: array, items: { type: string } }
             system_prompt: { type: string, description: "Read-only platform system prompt appended to every agent run." }
+            default_models:
+              type: object
+              additionalProperties: { type: string }
+              description: "Per-agent default model id (agent -> model), used when a task doesn't specify one. Editable via PATCH agents.default_models."
         presets:
           type: array
           items: { $ref: "#/components/schemas/Preset" }


### PR DESCRIPTION
Three coordinated changes so a fresh install can build immediately and never hang.

## 1. Never hang or fail silently on an agent task
- Engine surfaces `error_message` (with fallback) in the task summary.
- Console resolves the composer via a status poll + watchdog (not SSE `done` alone), and renders `error_message`.

## 2. OpenCode zero-friction free tier (no key needed)
- With no connected credential, the auth proxy forwards opencode to OpenCode Zen's keyless free models (drops the dummy key, injects nothing) instead of 401.
- Control plane defaults an un-connected opencode task to a free model (`big-pickle`, overridable via `SANDBOXD_OPENCODE_FREE_MODEL`).
- A connected key/subscription still wins and unlocks the full catalog. **opencode-only** — other agents still require connecting.
- Console un-gates the composer for opencode and shows a free-tier note.

## 3. Per-agent default model (added option)
- Editable in **Settings → AI Agents → Default model** and via `PATCH /v1/settings` `agents.default_models`.
- Persisted in `instance_settings` (migration 0023), applied live. User supplies the real model id.
- Precedence: per-task > per-agent default > opencode free tier > runtimed env/agent default.

Docs (`agent-auth.md`, `openapi.yaml`) updated. Go + console suites green; new tests for the keyless proxy branch and the default-models PATCH.