### PR TITLE
Fix OpenCode free tier: route to the zen endpoint (not zengo)

### DIFF
--- a/control-plane/internal/authproxy/proxy.go
+++ b/control-plane/internal/authproxy/proxy.go
@@ -72,6 +72,13 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	agent, up := segs[0], segs[1]
+	// OpenCode free tier: an unconnected opencode is served by Zen's keyless free
+	// models, which live ONLY on the `zen` endpoint. Force `zen` even if the
+	// operator pinned `zengo` (the go-subscription endpoint carries no free models,
+	// so a free-tier request there fails as "Model … is not supported").
+	if agent == "opencode" && p.store.Method("opencode") == "" {
+		up = "zen"
+	}
 	rest := "/"
 	if len(segs) == 3 {
 		rest = "/" + segs[2]

--- a/control-plane/internal/authproxy/proxy_test.go
+++ b/control-plane/internal/authproxy/proxy_test.go
@@ -154,21 +154,24 @@ func TestInjectsAnthropicAPIKeyHeader(t *testing.T) {
 // when unconnected (see TestServeNoCredential).
 func TestOpencodeFreeTierKeyless(t *testing.T) {
 	var gotAuth, gotKey, gotPath string
-	forwarded := false
+	zenHit, zengoHit := false, false
 	stubUpstream(t, "zen", func(w http.ResponseWriter, r *http.Request) {
-		forwarded = true
+		zenHit = true
 		gotAuth, gotKey, gotPath = r.Header.Get("Authorization"), r.Header.Get("X-Api-Key"), r.URL.Path
 		w.WriteHeader(200)
 	})
+	stubUpstream(t, "zengo", func(w http.ResponseWriter, _ *http.Request) { zengoHit = true; w.WriteHeader(200) })
 	p := New(agentauth.NewStore(t.TempDir()), nil) // nothing connected
 
-	req := httptest.NewRequest("POST", "/opencode/zen/v1/chat/completions", nil)
+	// The sandbox requests the `zengo` path (operator pinned it), but the free
+	// models live on `zen` — the proxy must override the upstream to `zen`.
+	req := httptest.NewRequest("POST", "/opencode/zengo/v1/chat/completions", nil)
 	req.Header.Set("Authorization", "Bearer sandboxd-proxy-injected") // the dummy the sandbox sends
 	w := httptest.NewRecorder()
 	p.ServeHTTP(w, req)
 
-	if !forwarded {
-		t.Fatalf("expected keyless forward to zen; got status %d (want 200 forward)", w.Code)
+	if !zenHit || zengoHit {
+		t.Fatalf("free tier must route to zen, not zengo (zenHit=%v zengoHit=%v, status %d)", zenHit, zengoHit, w.Code)
 	}
 	if gotAuth != "" {
 		t.Errorf("Authorization leaked to upstream: %q (free tier must send none)", gotAuth)
@@ -178,6 +181,33 @@ func TestOpencodeFreeTierKeyless(t *testing.T) {
 	}
 	if gotPath != "/v1/chat/completions" {
 		t.Errorf("forwarded path = %q; want /v1/chat/completions", gotPath)
+	}
+}
+
+// A CONNECTED opencode key is NOT rerouted — it keeps the operator's chosen
+// upstream (here zengo) and gets the real key injected.
+func TestConnectedOpencodeKeepsZengo(t *testing.T) {
+	var gotAuth string
+	zengoHit := false
+	stubUpstream(t, "zengo", func(w http.ResponseWriter, r *http.Request) {
+		zengoHit = true
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+	})
+	st := agentauth.NewStore(t.TempDir())
+	writeAPIKey(t, st, "opencode", "zen-REAL-KEY")
+	p := New(st, nil)
+
+	req := httptest.NewRequest("POST", "/opencode/zengo/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sandboxd-proxy-injected")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if !zengoHit {
+		t.Fatalf("connected opencode should keep zengo; status %d", w.Code)
+	}
+	if gotAuth != "Bearer zen-REAL-KEY" {
+		t.Errorf("Authorization = %q; want the injected real key", gotAuth)
 	}
 }
 

--- a/docs/agent-auth.md
+++ b/docs/agent-auth.md
@@ -94,8 +94,14 @@ set — go-subscription models (GLM/Kimi/…) for `zengo`.
 free models (ids ending `-free`, e.g. `big-pickle`, `deepseek-v4-flash-free`,
 `mimo-v2.5-free`) that need **no API key**. When opencode has no connected
 credential, the proxy forwards its requests to Zen **keyless** — it drops the
-sandbox's dummy key and injects nothing — and the control plane defaults the
+sandbox's dummy key and injects nothing — and always to the **`zen`** endpoint
+where the free models live (even if the deployment pins `zengo`, whose
+go-subscription catalog has no free models). The control plane defaults the
 task's model to a free one so a fresh install can build immediately.
+
+> Zen's API **requires a named model** — there is no keyless "auto" model, and
+> only the `-free` models work without a key. That's why a free model must be
+> named; it's not something opencode can pick on its own through the proxy.
 
 - **No key** → free tier. The default free model is `big-pickle`; override with
   `SANDBOXD_OPENCODE_FREE_MODEL`.


### PR DESCRIPTION
The free-tier request failed with **"Model big-pickle is not supported"** on this deployment because it is pinned to `SANDBOXD_OPENCODE_ZEN_PATH=zengo`. OpenCode Zen's free models (`big-pickle`, `*-free`) exist **only** on the `zen` endpoint; `zengo` (the go-subscription endpoint) has none.

Fix: for an **un-connected** opencode, the proxy now forces the `zen` upstream regardless of the operator's zengo setting. A **connected** key keeps the chosen upstream (zengo) and gets the real key injected — unchanged.

Also documents that Zen's API requires a named model (no keyless "auto" model), so a free model must be named. New tests cover the zengo→zen override and that connected opencode keeps zengo.