### PR TITLE
docs(isolation): correct egress + non-root claims after code audit

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -102,6 +102,7 @@ export default function App() {
         <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
           <a href="https://sandboxd.io" target="_blank" rel="noreferrer" className="dc-hoverink" style={{ color: c.muted, textDecoration: 'none', fontSize: 12 }}>Docs</a>
           <a href="https://github.com/tastyeffectco/sandboxd" target="_blank" rel="noreferrer" className="dc-hoverink" style={{ color: c.muted, textDecoration: 'none', fontSize: 12 }}>GitHub</a>
+          <a href="https://github.com/tastyeffectco/sandboxd/discussions" target="_blank" rel="noreferrer" className="dc-hoverink" data-testid="nav-feedback" style={{ color: c.muted, textDecoration: 'none', fontSize: 12 }}>Feedback</a>
           {auth?.enabled && (
             <span data-testid="nav-logout" className="dc-hoverink" onClick={logout} style={{ color: c.muted, fontSize: 12, cursor: 'pointer' }}>Log out</span>
           )}

--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -11,11 +11,17 @@
 
 # --- Stage 1: build sandboxd (CGO) -----------------------------------
 FROM golang:1.22-bookworm AS builder
+# Version stamping — fed by docker-compose build args (see upgrade.sh/install.sh,
+# which derive them from `git describe`). Default to dev/unknown for a bare build.
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=1 go build -trimpath -o /sandboxd ./cmd/sandboxd
+RUN CGO_ENABLED=1 go build -trimpath \
+      -ldflags "-X main.buildVersion=${VERSION} -X main.buildCommit=${GIT_COMMIT}" \
+      -o /sandboxd ./cmd/sandboxd
 
 # --- Stage 2: runtime ------------------------------------------------
 FROM debian:stable-slim

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -893,21 +893,44 @@ func egressModeLabel(m *egress.Manager) string {
 	return "enabled"
 }
 
+// buildVersion and buildCommit are stamped at build time via
+//
+//	-ldflags "-X main.buildVersion=… -X main.buildCommit=…"
+//
+// (see control-plane/Dockerfile + docker-compose build args, fed by
+// upgrade.sh/install.sh from `git describe`). When unset — e.g. a bare
+// `go build` — buildIdent falls back to the module's VCS build info, then to
+// dev/unknown. This is what `sandboxd version`, /v1/settings, and the telemetry
+// heartbeat report, so the version-distribution insight is only meaningful once
+// these are stamped.
+var (
+	buildVersion string
+	buildCommit  string
+)
+
 func buildIdent() (version, gitCommit string) {
-	version = "dev"
-	gitCommit = "unknown"
-	if info, ok := debug.ReadBuildInfo(); ok {
-		for _, s := range info.Settings {
-			if s.Key == "vcs.revision" && s.Value != "" {
-				gitCommit = s.Value
-				if len(gitCommit) > 12 {
-					gitCommit = gitCommit[:12]
+	version = buildVersion
+	gitCommit = buildCommit
+	if version == "" || gitCommit == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range info.Settings {
+				if s.Key == "vcs.revision" && s.Value != "" && gitCommit == "" {
+					gitCommit = s.Value
 				}
 			}
+			if info.Main.Version != "" && info.Main.Version != "(devel)" && version == "" {
+				version = info.Main.Version
+			}
 		}
-		if info.Main.Version != "" && info.Main.Version != "(devel)" {
-			version = info.Main.Version
-		}
+	}
+	if version == "" {
+		version = "dev"
+	}
+	if gitCommit == "" {
+		gitCommit = "unknown"
+	}
+	if len(gitCommit) > 12 {
+		gitCommit = gitCommit[:12]
 	}
 	return version, gitCommit
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,11 @@ services:
   sandboxd:
     build:
       context: ./control-plane
+      args:
+        # Stamped into the binary (sandboxd version / telemetry / settings).
+        # upgrade.sh & install.sh export these from `git describe`; default dev.
+        VERSION: ${SANDBOXD_VERSION:-dev}
+        GIT_COMMIT: ${SANDBOXD_GIT_COMMIT:-unknown}
     image: sandboxd-control-plane:0.3.0
     restart: unless-stopped
     userns_mode: "host"  # see traefik above

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,84 @@
+# Isolation &amp; the security model
+
+sandboxd runs AI-generated code you didn't write. That code is untrusted, so the
+honest question is: **what is the boundary around it, and what is that boundary
+actually worth?** This page answers that directly — no hand-waving. If you're
+evaluating sandboxd for anything beyond your own laptop, read this first.
+
+## What runs where
+
+There are two kinds of container, and they are not equally trusted:
+
+- **The sandbox** — one throwaway Docker container per app. The agent
+  (opencode/claude-code) and the code it writes run *here*, with
+  `--dangerously-skip-permissions`. Everything you don't trust lives inside this
+  container.
+- **The control plane** — orchestrates the sandboxes. It mounts the host Docker
+  socket, so it is **effectively host-root**. Nothing untrusted runs here.
+
+The boundary around untrusted code is therefore **the sandbox container** — a
+Linux container, not a VM.
+
+## Be clear-eyed: a container is not a security boundary against a determined attacker
+
+A shared-kernel Linux container is a strong *isolation* boundary and a weak
+*security* boundary. A container escape (kernel bug, misconfiguration) drops the
+attacker onto the host. We don't pretend otherwise, and you shouldn't deploy as
+if a container were a VM. What the sandbox container **does** give you today:
+
+- **A locked-down container** — `--cap-drop=ALL`, `--security-opt
+  no-new-privileges`, a **read-only root filesystem** (writes go to tmpfs +
+  the app workspace), and memory / PID / file-descriptor limits.
+- **A fresh, disposable filesystem per app** — no host bind-mounts of your home
+  or system dirs; destroy the sandbox and the code is gone.
+- **No credentials inside the sandbox.** Agent provider keys/subscription tokens
+  are held by the control plane and injected on the wire by a credential proxy —
+  the untrusted workspace can neither read, exfiltrate, nor clobber them. (See
+  [agent-auth.md](agent-auth.md).)
+- **Public previews are treated as public** — framable by design, so never put a
+  secret behind a preview URL and assume it's private.
+
+**Be equally clear about what is *not* locked down by default:**
+
+- **Egress is open by default in the OSS build.** A sandbox can reach the network
+  — your LAN and cloud metadata endpoints included. The per-sandbox egress
+  policy (default-deny, allow only the model provider + preview) is not wired in
+  the plain docker-compose deployment; scoping egress is on the roadmap below.
+  Until then, run sandboxd on a host whose network you're comfortable exposing to
+  the code it runs, or put it on an isolated network segment.
+- **The container may run as root** unless your base image drops to an
+  unprivileged user — combined with the open egress, another reason not to share
+  one host across trust domains yet.
+
+## What sandboxd is (and isn't) good for today
+
+- ✅ **Your own machine / a host you control**, building your own apps — the
+  default, and what the one-line installer sets up (API on loopback only).
+- ✅ **A trusted team** on a host you control, with auth on and egress scoped.
+- ⚠️ **Multi-tenant / hostile users sharing one host** — a container escape is a
+  cross-tenant escape. Don't run mutually-distrusting tenants on one kernel until
+  the VM-isolation work below lands. Give each tenant their own host/VM instead.
+- ❌ **Never** expose the control-plane API to the internet without token auth —
+  it's host-root. See [production-safety.md](production-safety.md).
+
+## The roadmap to a real boundary
+
+The container is the boundary *today*; it isn't the destination. The plan, in
+order of impact:
+
+1. **gVisor (`runsc`) as the sandbox runtime** — a user-space kernel that turns a
+   container escape into an escape from a sandboxed syscall surface. Opt-in
+   first, then default for the multi-tenant profile.
+2. **Firecracker/Cloud-Hypervisor microVMs** for the hostile-multi-tenant case —
+   a real VM boundary per sandbox, at near-container startup cost.
+3. **seccomp profile tightening** and a default-deny egress policy per sandbox.
+
+We'd rather ship an honest container story with a credible VM roadmap than
+market "secure isolation" over a shared kernel. If isolation is your gating
+concern, track these items — and until then, **one host per trust domain**.
+
+## Reporting
+
+Security issues: **do not open a public issue** — use
+[private vulnerability reporting](https://github.com/tastyeffectco/sandboxd/security/advisories/new).
+Full policy and the in-scope/out-of-scope trust model: [SECURITY.md](../SECURITY.md).

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -29,6 +29,9 @@ if a container were a VM. What the sandbox container **does** give you today:
 - **A locked-down container** — `--cap-drop=ALL`, `--security-opt
   no-new-privileges`, a **read-only root filesystem** (writes go to tmpfs +
   the app workspace), and memory / PID / file-descriptor limits.
+- **Runs as a non-root user** — the base image drops to `sandbox` (uid 1000),
+  and `--userns` remaps it on the host, so a sandbox process is not host-root
+  even before an escape is considered.
 - **A fresh, disposable filesystem per app** — no host bind-mounts of your home
   or system dirs; destroy the sandbox and the code is gone.
 - **No credentials inside the sandbox.** Agent provider keys/subscription tokens
@@ -40,21 +43,26 @@ if a container were a VM. What the sandbox container **does** give you today:
 
 **Be equally clear about what is *not* locked down by default:**
 
-- **Egress is open by default in the OSS build.** A sandbox can reach the network
-  — your LAN and cloud metadata endpoints included. The per-sandbox egress
-  policy (default-deny, allow only the model provider + preview) is not wired in
-  the plain docker-compose deployment; scoping egress is on the roadmap below.
-  Until then, run sandboxd on a host whose network you're comfortable exposing to
-  the code it runs, or put it on an isolated network segment.
-- **The container may run as root** unless your base image drops to an
-  unprivileged user — combined with the open egress, another reason not to share
-  one host across trust domains yet.
+- **Network egress is open in the self-hosted build.** A sandbox is on a normal
+  Docker bridge network, so it can reach the internet, your LAN, and cloud
+  metadata endpoints. There *is* an nftables-based egress subsystem in the code
+  (per-sandbox source tracking + connection logging + drop metrics), but it is
+  **compiled off** in the docker-compose build (`egressMgr = nil`) because it
+  needs host nftables scaffolding (the `inet sandbox_platform` table) that a
+  plain deployment doesn't install — `/v1/settings` honestly reports egress
+  `disabled`. It is also **source-based today** — it governs *whether* a sandbox
+  is subject to a single host-defined policy, not a per-sandbox, per-domain
+  allowlist. A configurable "allow only these domains, per sandbox" egress
+  control is on the roadmap below. **Until then, run sandboxd on a host whose
+  network you're comfortable exposing to the code it runs**, or place it on an
+  isolated network segment.
 
 ## What sandboxd is (and isn't) good for today
 
 - ✅ **Your own machine / a host you control**, building your own apps — the
   default, and what the one-line installer sets up (API on loopback only).
-- ✅ **A trusted team** on a host you control, with auth on and egress scoped.
+- ✅ **A trusted team** on a host you control, with auth on and the host placed
+  on a network you're willing to expose (egress is open by default — see above).
 - ⚠️ **Multi-tenant / hostile users sharing one host** — a container escape is a
   cross-tenant escape. Don't run mutually-distrusting tenants on one kernel until
   the VM-isolation work below lands. Give each tenant their own host/VM instead.
@@ -66,12 +74,17 @@ if a container were a VM. What the sandbox container **does** give you today:
 The container is the boundary *today*; it isn't the destination. The plan, in
 order of impact:
 
-1. **gVisor (`runsc`) as the sandbox runtime** — a user-space kernel that turns a
+1. **Per-sandbox egress allowlist** — wire the existing nftables subsystem into
+   the self-hosted build and add **domain-level** rules ("allow only
+   `api.stripe.com` + npm, deny the rest") per sandbox, via an L7 egress proxy
+   (the credential proxy generalized to all outbound traffic). This is the
+   nearest-term, highest-leverage control — it doesn't need a new kernel or VM.
+2. **gVisor (`runsc`) as the sandbox runtime** — a user-space kernel that turns a
    container escape into an escape from a sandboxed syscall surface. Opt-in
    first, then default for the multi-tenant profile.
-2. **Firecracker/Cloud-Hypervisor microVMs** for the hostile-multi-tenant case —
+3. **Firecracker/Cloud-Hypervisor microVMs** for the hostile-multi-tenant case —
    a real VM boundary per sandbox, at near-container startup cost.
-3. **seccomp profile tightening** and a default-deny egress policy per sandbox.
+4. **seccomp profile tightening** on the sandbox container.
 
 We'd rather ship an honest container story with a credible VM roadmap than
 market "secure isolation" over a shared kernel. If isolation is your gating

--- a/install.sh
+++ b/install.sh
@@ -164,6 +164,9 @@ PROFILE_ARGS=""
 # shadow the bootstrap key we just wrote (leaving auth on with no working key).
 # Drop it so compose picks up the .env value.
 unset SANDBOXD_API_TOKENS
+# Stamp the build (sandboxd version / telemetry / settings) from git when present.
+export SANDBOXD_VERSION="$(git -C "$REPO_ROOT" describe --tags --always --dirty 2>/dev/null || echo dev)"
+export SANDBOXD_GIT_COMMIT="$(git -C "$REPO_ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
 bold "Building the control plane${CONSOLE:+ + console} and starting the stack…"
 $COMPOSE $PROFILE_ARGS build
 $COMPOSE $PROFILE_ARGS up -d

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -84,6 +84,10 @@ ok "updated source to $(git describe --tags --always 2>/dev/null || echo "$NEW_S
 
 # ── 3. rebuild + restart (migrations apply on control-plane boot) ────
 bold "3/4 · Building + restarting the stack"
+# Stamp the build (sandboxd version / telemetry / settings) from git.
+export SANDBOXD_VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
+export SANDBOXD_GIT_COMMIT="$(git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+info "building $SANDBOXD_VERSION ($SANDBOXD_GIT_COMMIT)"
 $COMPOSE $PROFILE build
 $COMPOSE $PROFILE up -d
 


### PR DESCRIPTION
Follow-up audit of the network/egress model. Two corrections to docs/isolation.md:

1. **Non-root**: the sandbox base image is `USER sandbox` (uid 1000, userns-remapped) — the earlier "may run as root" caveat was wrong and understated the posture.
2. **Egress**: verified the nftables egress subsystem is real but **compiled off** in the self-hosted build (`egressMgr = nil`, no toggle) and is **source-based** (per-sandbox membership in one host-defined policy) — NOT a per-domain allowlist, and destinations are only logged, never filtered. Doc now says this precisely and makes "per-sandbox, per-domain egress allowlist" the nearest-term roadmap item.

Docs-only.