### PR TITLE
docs(isolation): correct egress + non-root claims (re-open of #67)

### DIFF
--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -29,6 +29,9 @@ if a container were a VM. What the sandbox container **does** give you today:
 - **A locked-down container** — `--cap-drop=ALL`, `--security-opt
   no-new-privileges`, a **read-only root filesystem** (writes go to tmpfs +
   the app workspace), and memory / PID / file-descriptor limits.
+- **Runs as a non-root user** — the base image drops to `sandbox` (uid 1000),
+  and `--userns` remaps it on the host, so a sandbox process is not host-root
+  even before an escape is considered.
 - **A fresh, disposable filesystem per app** — no host bind-mounts of your home
   or system dirs; destroy the sandbox and the code is gone.
 - **No credentials inside the sandbox.** Agent provider keys/subscription tokens
@@ -40,21 +43,26 @@ if a container were a VM. What the sandbox container **does** give you today:
 
 **Be equally clear about what is *not* locked down by default:**
 
-- **Egress is open by default in the OSS build.** A sandbox can reach the network
-  — your LAN and cloud metadata endpoints included. The per-sandbox egress
-  policy (default-deny, allow only the model provider + preview) is not wired in
-  the plain docker-compose deployment; scoping egress is on the roadmap below.
-  Until then, run sandboxd on a host whose network you're comfortable exposing to
-  the code it runs, or put it on an isolated network segment.
-- **The container may run as root** unless your base image drops to an
-  unprivileged user — combined with the open egress, another reason not to share
-  one host across trust domains yet.
+- **Network egress is open in the self-hosted build.** A sandbox is on a normal
+  Docker bridge network, so it can reach the internet, your LAN, and cloud
+  metadata endpoints. There *is* an nftables-based egress subsystem in the code
+  (per-sandbox source tracking + connection logging + drop metrics), but it is
+  **compiled off** in the docker-compose build (`egressMgr = nil`) because it
+  needs host nftables scaffolding (the `inet sandbox_platform` table) that a
+  plain deployment doesn't install — `/v1/settings` honestly reports egress
+  `disabled`. It is also **source-based today** — it governs *whether* a sandbox
+  is subject to a single host-defined policy, not a per-sandbox, per-domain
+  allowlist. A configurable "allow only these domains, per sandbox" egress
+  control is on the roadmap below. **Until then, run sandboxd on a host whose
+  network you're comfortable exposing to the code it runs**, or place it on an
+  isolated network segment.
 
 ## What sandboxd is (and isn't) good for today
 
 - ✅ **Your own machine / a host you control**, building your own apps — the
   default, and what the one-line installer sets up (API on loopback only).
-- ✅ **A trusted team** on a host you control, with auth on and egress scoped.
+- ✅ **A trusted team** on a host you control, with auth on and the host placed
+  on a network you're willing to expose (egress is open by default — see above).
 - ⚠️ **Multi-tenant / hostile users sharing one host** — a container escape is a
   cross-tenant escape. Don't run mutually-distrusting tenants on one kernel until
   the VM-isolation work below lands. Give each tenant their own host/VM instead.
@@ -66,12 +74,17 @@ if a container were a VM. What the sandbox container **does** give you today:
 The container is the boundary *today*; it isn't the destination. The plan, in
 order of impact:
 
-1. **gVisor (`runsc`) as the sandbox runtime** — a user-space kernel that turns a
+1. **Per-sandbox egress allowlist** — wire the existing nftables subsystem into
+   the self-hosted build and add **domain-level** rules ("allow only
+   `api.stripe.com` + npm, deny the rest") per sandbox, via an L7 egress proxy
+   (the credential proxy generalized to all outbound traffic). This is the
+   nearest-term, highest-leverage control — it doesn't need a new kernel or VM.
+2. **gVisor (`runsc`) as the sandbox runtime** — a user-space kernel that turns a
    container escape into an escape from a sandboxed syscall surface. Opt-in
    first, then default for the multi-tenant profile.
-2. **Firecracker/Cloud-Hypervisor microVMs** for the hostile-multi-tenant case —
+3. **Firecracker/Cloud-Hypervisor microVMs** for the hostile-multi-tenant case —
    a real VM boundary per sandbox, at near-container startup cost.
-3. **seccomp profile tightening** and a default-deny egress policy per sandbox.
+4. **seccomp profile tightening** on the sandbox container.
 
 We'd rather ship an honest container story with a credible VM roadmap than
 market "secure isolation" over a shared kernel. If isolation is your gating


### PR DESCRIPTION
Re-opens the #67 correction (that PR hit a lineage merge conflict and auto-closed). Cherry-picked cleanly onto current main. Sandbox runs non-root (uid 1000); egress subsystem is compiled off + source-based (not per-domain). Docs-only.