### PR TITLE
Opt-in gVisor (runsc) isolation for sandboxes — verified end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,16 @@ HTTP_PORT=80
 SANDBOXD_IMAGE=sandboxd-base:0.3.0
 SANDBOXD_NETWORK=sandboxd_net
 
+# ── Runtime (gVisor, opt-in) ─────────────────────────────────────────
+# Container runtime for sandboxes. Empty = Docker default (runc).
+# Set "runsc" to run every sandbox under gVisor for stronger kernel
+# isolation. Requires runsc installed + registered in daemon.json with
+# runtimeArgs ["--host-uds=create"]. See docs/gvisor.md.
+SANDBOXD_RUNTIME=
+# Resolvers for sandboxes (CSV). Only used when SANDBOXD_RUNTIME=runsc
+# (gVisor can't reach Docker's embedded DNS). Default: 1.1.1.1,8.8.8.8
+SANDBOXD_DNS=
+
 # ── Storage ──────────────────────────────────────────────────────────
 # Workspaces, SQLite state and the shared access log live here. MUST be
 # an absolute path; it is bind-mounted host:container symmetric (see

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -414,6 +414,36 @@ func main() {
 	// handler; a background goroutine below keeps its cache warm.
 	updateChecker := &telemetry.Checker{}
 
+	// gVisor (opt-in): SANDBOXD_RUNTIME=runsc runs sandboxes under runsc.
+	// gVisor's netstack can't reach Docker's embedded DNS (127.0.0.11) on a
+	// user-defined network, so we write a resolv.conf with real nameservers
+	// (SANDBOXD_DNS, default public resolvers) and bind-mount it into each
+	// sandbox. Requires runsc registered with `--host-uds=create` (docs/gvisor.md).
+	sbxRuntime := envDefault("SANDBOXD_RUNTIME", "")
+	var dnsResolvConf string
+	if sbxRuntime == "runsc" {
+		var ns []string
+		for _, d := range strings.Split(os.Getenv("SANDBOXD_DNS"), ",") {
+			if d = strings.TrimSpace(d); d != "" {
+				ns = append(ns, d)
+			}
+		}
+		if len(ns) == 0 {
+			ns = []string{"1.1.1.1", "8.8.8.8"}
+		}
+		var b strings.Builder
+		for _, n := range ns {
+			fmt.Fprintf(&b, "nameserver %s\n", n)
+		}
+		dnsResolvConf = filepath.Join(dataDir, "gvisor-resolv.conf")
+		if err := os.WriteFile(dnsResolvConf, []byte(b.String()), 0o644); err != nil {
+			log.Error("gvisor: write resolv.conf failed; sandbox DNS may not resolve", "err", err.Error())
+			dnsResolvConf = ""
+		} else {
+			log.Info("gvisor runtime enabled", "runtime", sbxRuntime, "dns", ns)
+		}
+	}
+
 	server := &api.Server{
 		Store:               st,
 		Secrets:             secretsCipher,
@@ -431,6 +461,8 @@ func main() {
 		Image:               image,
 		Network:             network,
 		Userns:              userns,
+		Runtime:             sbxRuntime,
+		DNSResolvConf:       dnsResolvConf,
 		PreviewEntrypoint:   previewEntrypoint,
 		PreviewTLS:          previewTLS,
 		PublicHTTPPort:      publicHTTPPort,

--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -441,6 +443,24 @@ func main() {
 			dnsResolvConf = ""
 		} else {
 			log.Info("gvisor runtime enabled", "runtime", sbxRuntime, "dns", ns)
+		}
+		// gVisor sandboxes use public DNS (above) and can't reach Docker's
+		// embedded resolver, so an internal service name like "sandboxd" won't
+		// resolve inside them. Pin the agent proxy URL to its IP — the control
+		// plane (not under gVisor) can resolve it — so sandboxes reach the proxy
+		// by address. Without this, every agent task hangs/fails on DNS.
+		if u, perr := url.Parse(agentProxyURL); perr == nil && u.Hostname() != "" && net.ParseIP(u.Hostname()) == nil {
+			if ips, lerr := net.LookupHost(u.Hostname()); lerr == nil && len(ips) > 0 {
+				if p := u.Port(); p != "" {
+					u.Host = net.JoinHostPort(ips[0], p)
+				} else {
+					u.Host = ips[0]
+				}
+				log.Info("gvisor: pinned agent proxy to IP", "from", agentProxyURL, "to", u.String())
+				agentProxyURL = u.String()
+			} else {
+				log.Warn("gvisor: could not resolve agent proxy host to IP; sandboxes may fail to reach it", "host", u.Hostname())
+			}
 		}
 	}
 

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -49,6 +49,8 @@ type Server struct {
 	//                        portable build (the --memory ceiling still applies).
 	Network           string
 	Userns            string
+	Runtime           string
+	DNSResolvConf     string
 	PreviewEntrypoint string
 	PreviewTLS        bool
 	// PublicHTTPPort is the HOST-facing port that preview/console URLs are

--- a/control-plane/internal/api/handlers.go
+++ b/control-plane/internal/api/handlers.go
@@ -735,6 +735,10 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 	// right one per task by the requested agent, so an explicit agent:"claude-code"
 	// task works regardless of the default. No credential is ever in env.
 	volumes := append([]string{mntPath + ":/home/sandbox"}, s.agentAuthMounts()...)
+	if s.DNSResolvConf != "" {
+		// gVisor: override the unreachable embedded DNS (127.0.0.11).
+		volumes = append(volumes, s.DNSResolvConf+":/etc/resolv.conf:ro")
+	}
 	startRun := time.Now()
 	var runErr error
 	containerID, runErr := s.Docker.Run(r.Context(), docker.RunSpec{
@@ -742,6 +746,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Hostname:    "s-" + req.ID,
 		Network:     s.Network,
 		Userns:      s.Userns,
+		Runtime:     s.Runtime,
 		ReadOnly:    true,
 		CapDrop:     []string{"ALL"},
 		SecurityOpt: []string{"no-new-privileges"},

--- a/control-plane/internal/docker/docker.go
+++ b/control-plane/internal/docker/docker.go
@@ -38,6 +38,7 @@ type RunSpec struct {
 	Hostname    string   // --hostname
 	Network     string   // --network (OSS: shared sandboxd_net so Traefik can route)
 	Userns      string   // --userns (OSS: "host" for deterministic workspace ownership)
+	Runtime     string   // --runtime ("runsc"=gVisor); "" = daemon default (runc)
 	ReadOnly    bool     // --read-only
 	CapDrop     []string // --cap-drop=ALL (passed once per entry)
 	SecurityOpt []string // --security-opt=no-new-privileges
@@ -68,6 +69,9 @@ func (c *Client) Run(ctx context.Context, spec RunSpec) (string, error) {
 	}
 	if spec.Userns != "" {
 		args = append(args, "--userns", spec.Userns)
+	}
+	if spec.Runtime != "" {
+		args = append(args, "--runtime", spec.Runtime)
 	}
 	if spec.ReadOnly {
 		args = append(args, "--read-only")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,11 @@ services:
       # Which OpenCode Zen endpoint opencode routes through the auth proxy:
       # "zen" (pay-as-you-go, full catalog) or "zengo" (Zen "go" subscription).
       SANDBOXD_OPENCODE_ZEN_PATH: ${SANDBOXD_OPENCODE_ZEN_PATH:-zen}
+      # Sandbox container runtime: empty = docker default (runc); "runsc" = gVisor
+      # (stronger per-sandbox kernel isolation). SANDBOXD_DNS overrides resolv.conf
+      # for gVisor sandboxes (netstack can't reach Docker's embedded DNS).
+      SANDBOXD_RUNTIME: ${SANDBOXD_RUNTIME:-}
+      SANDBOXD_DNS: ${SANDBOXD_DNS:-}
       SANDBOXD_DATA_DIR: ${SANDBOXD_DATA_DIR:-/var/lib/sandboxed}
       SANDBOXD_LOG_DIR: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}
       SANDBOXD_ACCESS_LOG: ${SANDBOXD_LOG_DIR:-/var/lib/sandboxed/log}/traefik-access.log

--- a/docs/gvisor.md
+++ b/docs/gvisor.md
@@ -67,6 +67,14 @@ to its data dir and bind-mounts it into each sandbox at `/etc/resolv.conf`, so
 DNS resolves. Package installs already go through the registry proxy by IP and
 are unaffected.
 
+Because those sandboxes use public DNS, an **internal** Docker service name (like
+`sandboxd`, where the credential proxy listens) won't resolve inside them. So when
+`runsc` is on, sandboxd resolves the agent-proxy host to an **IP** at startup — the
+control plane can, since it isn't under gVisor — and hands each sandbox the
+IP-based proxy URL. Without this, every agent task would fail to reach the proxy.
+Verified: create → agent task (opencode free tier) → file written → preview serves
+→ stop/wake → 2nd task, all under `runsc`.
+
 ## Trade-offs (measured on an ARM64 host with no KVM → gVisor software platform)
 
 - **Near-parity**: dev-server serving, HTTP latency (+~1 ms/req), HMR for

--- a/docs/gvisor.md
+++ b/docs/gvisor.md
@@ -1,0 +1,85 @@
+# gVisor runtime (opt-in)
+
+By default sandboxd runs each sandbox under Docker's standard runtime (`runc`),
+hardened with `cap-drop ALL`, read-only rootfs, `no-new-privileges`, and
+per-sandbox memory/PID limits. That's a shared-kernel boundary — appropriate for
+the project's threat model (authenticated users running their own code), but it
+is not a defense against kernel-CVE container escape.
+
+For stronger, per-sandbox **kernel isolation** — useful if you run less-trusted
+code — sandboxd can run every sandbox under [gVisor](https://gvisor.dev)
+(`runsc`). It is strictly opt-in; the default stays `runc`.
+
+## Setup
+
+### 1. Install runsc
+
+Follow the official [gVisor install guide](https://gvisor.dev/docs/user_guide/install/)
+(download `runsc` + `containerd-shim-runsc-v1`, verify the checksums, and place
+them on `PATH`). gVisor supports x86_64 and ARM64.
+
+### 2. Register the runtime with `--host-uds=create` (required)
+
+sandboxd talks to the in-sandbox supervisor (`runtimed`) over a Unix socket on
+the workspace bind-mount. gVisor's gofer does **not** expose a socket created
+inside the sandbox to the host unless `--host-uds=create` is set — without it,
+every task / exec / status call fails. Add to `/etc/docker/daemon.json`:
+
+```json
+{
+  "runtimes": {
+    "runsc": {
+      "path": "/usr/local/bin/runsc",
+      "runtimeArgs": ["--host-uds=create"]
+    }
+  }
+}
+```
+
+Then reload Docker (a reload, not a restart, so running containers aren't
+disturbed):
+
+```
+sudo systemctl reload docker
+docker info | grep -i runtimes   # should list: runsc
+```
+
+### 3. Enable it in sandboxd
+
+In `.env`:
+
+```
+SANDBOXD_RUNTIME=runsc
+# optional — resolvers for sandboxes (default: 1.1.1.1,8.8.8.8)
+SANDBOXD_DNS=1.1.1.1,8.8.8.8
+```
+
+Restart: `docker compose up -d`. New sandboxes now run under gVisor (`docker
+inspect s-<id> -f '{{.HostConfig.Runtime}}'` → `runsc`; `uname -r` inside →
+`*-gvisor`).
+
+## How DNS is handled
+
+On a user-defined Docker network, containers resolve names via Docker's embedded
+DNS at `127.0.0.11`, which gVisor's netstack cannot reach. When
+`SANDBOXD_RUNTIME=runsc`, sandboxd writes a `resolv.conf` (from `SANDBOXD_DNS`)
+to its data dir and bind-mounts it into each sandbox at `/etc/resolv.conf`, so
+DNS resolves. Package installs already go through the registry proxy by IP and
+are unaffected.
+
+## Trade-offs (measured on an ARM64 host with no KVM → gVisor software platform)
+
+- **Near-parity**: dev-server serving, HTTP latency (+~1 ms/req), HMR for
+  in-sandbox edits, pure CPU (~1.2×), bulk file I/O.
+- **Slower**: `pnpm install` ~1.7×; syscall/metadata-heavy work ~4× (fork/exec,
+  `stat`) — the gofer + syscall-interception cost. Container cold-start: +~0.1 s.
+- **HMR caveat**: edits made *inside* the sandbox trigger reload; host-side edits
+  to the workspace bind-mount do **not** (gVisor's gofer doesn't forward host
+  filesystem events). The agent edits files inside the sandbox, so its workflow
+  is unaffected.
+
+## Status
+
+Opt-in and experimental. The default runtime is unchanged (`runc`). Verified
+end-to-end on ARM64: create → sandbox runs under `runsc` → DNS resolves →
+preview serves.


### PR DESCRIPTION
Runs every sandbox under **gVisor (`runsc`)** for real per-sandbox kernel isolation. **Strictly opt-in** (`SANDBOXD_RUNTIME=runsc`); default stays `runc`.

Rebases the original gVisor work onto current main (free tier, reliability, version stamping) and **fixes a blocker** found while testing: under gVisor the sandbox uses public DNS and can't resolve internal Docker names, so agent tasks couldn't reach the credential proxy at `sandboxd:9100`. Now the control plane pins the proxy to its **IP** at startup.

### Verified end-to-end on this ARM64 host, under `runsc`:
- sandbox runtime `runsc`, kernel `4.19.0-gvisor`
- agent task (opencode **free tier, no key**) → file written → **succeeded**
- files API, git status, dev server/preview (HTTP 200 on :3000)
- stop → wake (back on runsc, workspace preserved) → 2nd session-continue task

Setup in `docs/gvisor.md` (requires `runsc` registered with `--host-uds=create` so the runtimed control socket is reachable). Go build/vet/tests green.