### PR TITLE
fix(files): console editor saves now persist (write to app dir, not workspace root)

### DIFF
--- a/control-plane/internal/api/v1_files_write.go
+++ b/control-plane/internal/api/v1_files_write.go
@@ -136,7 +136,12 @@ func (s *Server) v1PutFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	full, rel, err := resolveWritePath(mnt, r.URL.Query().Get("path"))
+	// Paths are relative to the APP dir (workspace/app), matching GET /files and
+	// /files/content. Writing relative to the workspace root instead left console
+	// editor saves invisible to reads (they landed a directory above the app), so
+	// the editor looked read-only. appDirFor is under mnt, so the chown-up loop
+	// below (bounded by mnt) still fixes ownership of any dirs it creates.
+	full, rel, err := resolveWritePath(s.appDirFor(id), r.URL.Query().Get("path"))
 	if err != nil {
 		writeV1Err(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return


### PR DESCRIPTION
**Bug:** the in-console file editor looked read-only — you could type but saves didn't stick.

**Cause:** `PUT /v1/sandboxes/{id}/files` resolved the path against the **workspace root**, while `GET /files` and `/files/content` use the **app dir** (`workspace/app`). So a save to `src/main.tsx` landed at `<ws>/src/main.tsx` instead of `<ws>/workspace/app/src/main.tsx`; reloading read the unchanged app-dir copy → looked read-only.

**Fix:** resolve writes against `appDirFor(id)`, consistent with reads. One-liner; the existing chown-up loop (bounded by the workspace root) still fixes ownership.

**Verified end-to-end:** edited `src/main.tsx` via the API (path as the console sends it) → readback returns the edit → visible inside the sandbox. api tests green.