### PR TITLE
feat: in-sandbox terminal in the console (WebSocket + PTY)

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -21,6 +21,8 @@
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
     "@uiw/react-codemirror": "^4.25.10",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@uiw/react-codemirror':
         specifier: ^4.25.10
         version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -656,6 +662,14 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -1790,6 +1804,12 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   agent-base@7.1.4: {}
 

--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -6,9 +6,10 @@ import { DeployModal } from './DeployModal'
 // Code-split the CodeMirror editor: it's the app's heaviest dependency and only
 // needed on the Files tab, so it loads on demand rather than in the main bundle.
 const CodeEditor = lazy(() => import('./CodeEditor').then((m) => ({ default: m.CodeEditor })))
+const SandboxTerminal = lazy(() => import('./Terminal').then((m) => ({ default: m.SandboxTerminal })))
 
 type Msg = { role: 'user' | 'agent'; text: string; taskId?: string; done?: boolean }
-const TABS = ['overview', 'files', 'git', 'config', 'snapshots', 'activity'] as const
+const TABS = ['overview', 'files', 'git', 'config', 'terminal', 'snapshots', 'activity'] as const
 type Tab = (typeof TABS)[number]
 
 // Per-app agent context (Layer 2). Platform/sandbox conventions come from the
@@ -132,7 +133,7 @@ export function AppView({
     catch (e) { onError((e as Error).message) }
   }
 
-  const tabBadge: Record<Tab, string> = { overview: '', files: '', git: '', config: '', snapshots: '', activity: '' }
+  const tabBadge: Record<Tab, string> = { overview: '', files: '', git: '', config: '', terminal: '', snapshots: '', activity: '' }
 
   return (
     <div style={{ maxWidth: 1320, margin: '0 auto', padding: '28px 40px 80px' }}>
@@ -196,6 +197,11 @@ export function AppView({
       {tabName === 'files' && <FilesTab appId={appId} sb={sb} onError={onError} toast={toast} />}
       {tabName === 'git' && <GitTab appId={appId} onError={onError} toast={toast} goSettings={goSettings} />}
       {tabName === 'config' && <ConfigTab appId={appId} onError={onError} />}
+      {tabName === 'terminal' && (
+        sb && status === 'running'
+          ? <Suspense fallback={<div style={{ padding: 30, color: c.muted2, fontSize: 13 }}>Loading terminal…</div>}><SandboxTerminal key={sb.id} sandboxId={sb.id} /></Suspense>
+          : <div style={{ padding: 44, textAlign: 'center', color: c.muted2, fontSize: 13 }}>Start the sandbox to open a terminal.</div>
+      )}
       {tabName === 'snapshots' && <SnapshotsTab appId={appId} appName={app.name} onError={onError} toast={toast} refresh={refresh} sb={sb} />}
       {tabName === 'activity' && <ActivityTab appId={appId} onError={onError} />}
       {deployOpen && <DeployModal appName={app.name} close={() => setDeployOpen(false)} />}

--- a/console/src/Terminal.tsx
+++ b/console/src/Terminal.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+import { Terminal as XTerm } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+
+// SandboxTerminal — an interactive shell inside the sandbox (uid 1000, the app
+// workspace), streamed over a WebSocket to the /v1/sandboxes/{id}/terminal
+// endpoint. Protocol: BINARY frames carry keystrokes (client→server) and shell
+// output (server→client); a TEXT frame `{"resize":{cols,rows}}` reports size.
+export function SandboxTerminal({ sandboxId }: { sandboxId: string }) {
+  const host = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = host.current
+    if (!el) return
+
+    const term = new XTerm({
+      cursorBlink: true,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      fontSize: 13,
+      theme: { background: '#0a0d14', foreground: '#c6d0de', cursor: '#7c93ff', selectionBackground: '#2c374d' },
+    })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(el)
+    try { fit.fit() } catch { /* not yet laid out */ }
+
+    const proto = location.protocol === 'https:' ? 'wss' : 'ws'
+    const ws = new WebSocket(`${proto}://${location.host}/v1/sandboxes/${sandboxId}/terminal`)
+    ws.binaryType = 'arraybuffer'
+    const enc = new TextEncoder()
+
+    const sendResize = () => {
+      try { fit.fit() } catch { /* ignore */ }
+      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ resize: { cols: term.cols, rows: term.rows } }))
+    }
+
+    ws.onopen = () => { term.focus(); sendResize() }
+    ws.onmessage = (e) => term.write(new Uint8Array(e.data as ArrayBuffer))
+    ws.onclose = () => term.write('\r\n\x1b[90m[ session closed ]\x1b[0m\r\n')
+    ws.onerror = () => term.write('\r\n\x1b[31m[ connection error ]\x1b[0m\r\n')
+
+    const inputSub = term.onData((d) => { if (ws.readyState === WebSocket.OPEN) ws.send(enc.encode(d)) })
+    const ro = new ResizeObserver(() => sendResize())
+    ro.observe(el)
+
+    return () => {
+      inputSub.dispose()
+      ro.disconnect()
+      ws.close()
+      term.dispose()
+    }
+  }, [sandboxId])
+
+  return <div ref={host} style={{ height: 500, width: '100%', background: '#0a0d14', padding: 8, borderRadius: 8, overflow: 'hidden' }} />
+}

--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -3,6 +3,8 @@ module github.com/tastyeffectco/sandboxd/control-plane
 go 1.22
 
 require (
+	github.com/creack/pty v1.1.24
+	github.com/gorilla/websocket v1.5.3
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/prometheus/client_golang v1.20.5

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -3,8 +3,12 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/control-plane/internal/api/api.go
+++ b/control-plane/internal/api/api.go
@@ -3,7 +3,10 @@
 package api
 
 import (
+	"bufio"
+	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -243,6 +246,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("PUT /v1/sandboxes/{id}/files", s.observe("PUT /v1/sandboxes/{id}/files", s.v1PutFile))
 	mux.HandleFunc("GET /v1/sandboxes/{id}/export", s.observe("GET /v1/sandboxes/{id}/export", s.v1Export))
 	mux.HandleFunc("GET /v1/sandboxes/{id}/processes/{name}/logs", s.observe("GET /v1/sandboxes/{id}/processes/{name}/logs", s.v1ProcessLogs))
+	mux.HandleFunc("GET /v1/sandboxes/{id}/terminal", s.observe("GET /v1/sandboxes/{id}/terminal", s.v1Terminal))
 
 	// Durable apps above sandboxes (Phase 1).
 	mux.HandleFunc("GET /v1/settings", s.observe("GET /v1/settings", s.v1GetSettings))
@@ -331,6 +335,16 @@ func (w *statusWriter) Flush() {
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Hijack forwards to the wrapped writer so a WebSocket upgrade (the in-sandbox
+// terminal) can take over the connection. Without it this wrapper hides
+// http.Hijacker and the upgrade fails.
+func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("ResponseWriter does not support hijacking")
 }
 
 func statusBucket(code int) string {

--- a/control-plane/internal/api/v1_terminal.go
+++ b/control-plane/internal/api/v1_terminal.go
@@ -1,0 +1,131 @@
+// In-sandbox terminal — GET /v1/sandboxes/{id}/terminal (WebSocket).
+//
+// Bridges a browser terminal (xterm.js) to an interactive shell running INSIDE
+// the sandbox as uid 1000 in the app workspace. This runs in the SAME locked-down
+// container the coding agent already executes arbitrary code in
+// (--dangerously-skip-permissions), so it adds NO new trust boundary — it's just
+// a direct interface to what an authenticated operator can already do. Auth is
+// enforced by the middleware before the upgrade; the sandbox is tenant-scoped.
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/creack/pty"
+	"github.com/gorilla/websocket"
+
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+)
+
+var terminalUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	// Same-origin only (the console is served same-origin as the API). A missing
+	// Origin means a non-browser client (e.g. a CLI) — auth still gates it.
+	CheckOrigin: func(r *http.Request) bool {
+		o := r.Header.Get("Origin")
+		if o == "" {
+			return true
+		}
+		u, err := url.Parse(o)
+		return err == nil && u.Host == r.Host
+	},
+}
+
+// termResize is the only control message the client sends as a TEXT frame;
+// keystrokes come as BINARY frames.
+type termResize struct {
+	Resize *struct {
+		Cols uint16 `json:"cols"`
+		Rows uint16 `json:"rows"`
+	} `json:"resize"`
+}
+
+func (s *Server) v1Terminal(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isULID(id) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such sandbox")
+		return
+	}
+	sb, err := s.Store.Get(r.Context(), id)
+	if errors.Is(err, store.ErrNotFound) {
+		writeV1Err(w, http.StatusNotFound, "not_found", "no such sandbox")
+		return
+	}
+	if err != nil {
+		writeV1Err(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if sb.Status != "running" {
+		writeV1Err(w, http.StatusConflict, "conflict", "sandbox is "+sb.Status+" — start it to open a terminal")
+		return
+	}
+
+	conn, err := terminalUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return // Upgrade already responded on failure.
+	}
+	defer conn.Close()
+
+	// Keep the sandbox warm for the length of the session (mirrors handleExec).
+	if s.Inflight != nil {
+		s.Inflight.Enter(id)
+		defer s.Inflight.Exit(id)
+	}
+
+	// Interactive login shell as uid 1000 in the app workspace. Prefer bash,
+	// fall back to sh for a minimal base image.
+	ptmx, cmd, err := s.Docker.ExecTTY("s-"+id, "sandbox", "/home/sandbox/workspace/app",
+		[]string{"/bin/sh", "-c", "command -v bash >/dev/null && exec bash -l || exec sh"})
+	if err != nil {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("\r\n[sandboxd] could not open terminal: "+err.Error()+"\r\n"))
+		return
+	}
+	defer func() {
+		_ = ptmx.Close()
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+
+	// PTY output → WebSocket (binary frames). Closing conn on EOF unblocks the
+	// reader loop below.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, rerr := ptmx.Read(buf)
+			if n > 0 {
+				if werr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); werr != nil {
+					return
+				}
+			}
+			if rerr != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	}()
+
+	// WebSocket → PTY. Binary = keystrokes (stdin); text = a JSON resize control.
+	for {
+		mt, data, rerr := conn.ReadMessage()
+		if rerr != nil {
+			return // client gone → deferred teardown kills the shell
+		}
+		switch mt {
+		case websocket.BinaryMessage:
+			if _, werr := ptmx.Write(data); werr != nil {
+				return
+			}
+		case websocket.TextMessage:
+			var ctl termResize
+			if json.Unmarshal(data, &ctl) == nil && ctl.Resize != nil {
+				_ = pty.Setsize(ptmx, &pty.Winsize{Cols: ctl.Resize.Cols, Rows: ctl.Resize.Rows})
+			}
+		}
+	}
+}

--- a/control-plane/internal/api/v1_terminal_test.go
+++ b/control-plane/internal/api/v1_terminal_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+)
+
+func newTerminalServer(t *testing.T) *Server {
+	t.Helper()
+	st, err := store.Open(context.Background(), "file::memory:?_fk=1", "../../migrations")
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return &Server{Store: st, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// callTerminal invokes v1Terminal with the id as a path value (no WebSocket
+// upgrade happens on the guard paths, so a plain recorder is fine).
+func callTerminal(s *Server, id string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodGet, "/v1/sandboxes/"+id+"/terminal", nil)
+	r.SetPathValue("id", id)
+	w := httptest.NewRecorder()
+	s.v1Terminal(w, r)
+	return w
+}
+
+// The terminal endpoint guards before upgrading: bad id and unknown sandbox 404,
+// and a non-running sandbox is a 409 (you must start it first).
+func TestTerminalGuards(t *testing.T) {
+	s := newTerminalServer(t)
+
+	if w := callTerminal(s, "not-a-ulid"); w.Code != http.StatusNotFound {
+		t.Errorf("bad id: got %d, want 404", w.Code)
+	}
+	if w := callTerminal(s, newULID()); w.Code != http.StatusNotFound {
+		t.Errorf("unknown sandbox: got %d, want 404", w.Code)
+	}
+
+	stopped := &store.Sandbox{ID: newULID(), Status: "stopped", ExternalUserID: nullStr("local")}
+	if err := s.Store.Create(context.Background(), stopped); err != nil {
+		t.Fatal(err)
+	}
+	if w := callTerminal(s, stopped.ID); w.Code != http.StatusConflict {
+		t.Errorf("stopped sandbox: got %d, want 409", w.Code)
+	}
+}

--- a/control-plane/internal/docker/docker.go
+++ b/control-plane/internal/docker/docker.go
@@ -15,8 +15,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/creack/pty"
 )
 
 // ErrNotFound is returned when `docker inspect` reports the target
@@ -288,6 +291,30 @@ func (c *Client) Exec(ctx context.Context, name string, cmd []string) (ExecResul
 		return res, nil
 	}
 	return res, err
+}
+
+// ExecTTY starts an INTERACTIVE command in the named container over a PTY and
+// returns the PTY master + the running *exec.Cmd. `-i -t` gives the in-container
+// process a real terminal; user/workdir scope it (e.g. uid-1000 "sandbox" in the
+// app workspace). The caller streams the PTY to a client, resizes it with
+// pty.Setsize, and MUST Close the PTY and Kill the process when the session ends.
+// This is the interactive counterpart to Exec (which is deliberately one-shot).
+func (c *Client) ExecTTY(name, user, workdir string, argv []string) (*os.File, *exec.Cmd, error) {
+	args := []string{"exec", "-i", "-t"}
+	if user != "" {
+		args = append(args, "-u", user)
+	}
+	if workdir != "" {
+		args = append(args, "-w", workdir)
+	}
+	args = append(args, name)
+	args = append(args, argv...)
+	cmd := exec.Command(c.Bin, args...)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ptmx, cmd, nil
 }
 
 // ListByNamePrefix returns the names of all containers (any state)

--- a/control-plane/internal/logging/logging.go
+++ b/control-plane/internal/logging/logging.go
@@ -7,9 +7,12 @@
 package logging
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
+	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -93,4 +96,13 @@ func (w *statusWriter) Flush() {
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// Hijack forwards to the wrapped writer so a WebSocket upgrade (the in-sandbox
+// terminal) can take over the connection through this logging middleware.
+func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("ResponseWriter does not support hijacking")
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1354,6 +1354,24 @@ paths:
             application/zip:
               schema: { type: string, format: binary }
 
+  /v1/sandboxes/{id}/terminal:
+    parameters: [ { $ref: "#/components/parameters/Id" } ]
+    get:
+      operationId: sandboxTerminal
+      tags: [sandboxes]
+      summary: Interactive terminal (WebSocket)
+      description: >
+        Upgrades to a WebSocket and bridges an interactive shell running INSIDE
+        the sandbox (uid 1000, the app workspace) to a browser terminal. It runs
+        in the same container the coding agent executes in, so it adds no new
+        trust boundary. Frames: BINARY = keystrokes (client→server) and shell
+        output (server→client); a TEXT frame `{"resize":{"cols","rows"}}` sets the
+        size. Requires the sandbox to be running.
+      responses:
+        "101": { description: Switching Protocols (WebSocket) }
+        "409": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+
   /v1/snapshots:
     get:
       operationId: listSnapshots


### PR DESCRIPTION
Adds the missing piece of the browser IDE: an **interactive terminal** in the console — a shell running **inside the sandbox** as uid 1000 in the app workspace, streamed to **xterm.js** over a **WebSocket**.

### Core (sandboxd)
- `docker.Client.ExecTTY` — interactive `docker exec -it` over a `creack/pty` PTY (interactive counterpart to the one-shot `Exec`).
- `GET /v1/sandboxes/{id}/terminal` — upgrades to a WebSocket (`gorilla/websocket`), bridges PTY ↔ WS (binary = keystrokes/output; text `{"resize":{cols,rows}}` = size), keeps the sandbox warm via `Inflight`, kills the shell on disconnect. Guards: 404 bad/unknown, 409 not-running; same-origin check; auth via the existing middleware.
- `statusWriter.Hijack` passthrough (api + logging wrappers) so the upgrade survives the middleware chain.

### Console
- A **Terminal** tab (xterm.js + fit addon), shown when the sandbox is running.

### Security
No new trust boundary — it runs in the **same container the agent already executes arbitrary code in** (`--dangerously-skip-permissions`), as **non-root uid 1000**. Just an authenticated, direct interface.

**Verified end-to-end (including under gVisor):** interactive `bash` as `USER=sandbox`, `UID=1000`, in `/home/sandbox/workspace/app`, real TTY (prompt, echo, bracketed paste). Go build/vet/tests + console tsc/build all green; OpenAPI updated + a guard test added.