### PR TITLE
fix(console): terminal WebSocket died with 400 through the console nginx

### DIFF
--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -1,3 +1,11 @@
+# WebSocket-aware Connection header: "upgrade" only when the client asks for an
+# upgrade (the in-sandbox terminal); empty otherwise, so SSE/keep-alive proxying
+# behaves exactly as before.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}
+
 server {
     listen 80;
     server_name _;
@@ -19,7 +27,8 @@ server {
         proxy_pass http://$sandboxd_upstream$request_uri;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
-        proxy_set_header Connection "";
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
         # Preserve the client's scheme (set by Traefik) so the control plane can
         # decide whether to mark the session cookie Secure. The Cookie request
         # header and upstream Set-Cookie both pass through by default.


### PR DESCRIPTION
The nginx /v1 proxy cleared `Connection` and never forwarded `Upgrade`, so the terminal (#73) WebSocket handshake failed with an instant 400 on every deployment that uses the console (the only path real users take — direct control-plane access worked, which is how it slipped through verification).

Fix: standard `map $http_upgrade $connection_upgrade` — `Connection: upgrade` is sent only when the client asks to upgrade; all other requests (REST, SSE) proxy exactly as before.

Verified on a live deployment: handshake through the console nginx went 400 → 101 with an interactive PTY; REST + SPA + SSE unaffected.