### PR TITLE
fix(console): terminal origin check failed on non-default ports ($host strips the port)

### DIFF
--- a/console/nginx.conf
+++ b/console/nginx.conf
@@ -26,7 +26,10 @@ server {
         set $sandboxd_upstream "sandboxd:9000";
         proxy_pass http://$sandboxd_upstream$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        # $http_host (not $host) — keep the port the client sent, so the control
+        # plane's same-origin check on the terminal WebSocket matches the
+        # browser's Origin header on non-default ports (e.g. :18080).
+        proxy_set_header Host $http_host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         # Preserve the client's scheme (set by Traefik) so the control plane can


### PR DESCRIPTION
Follow-up to #77. With upgrade headers forwarded, the handshake still failed for real browsers on non-default ports: nginx's `$host` drops the port from the proxied `Host` header, so the control plane compared `console.example.com` against the browser Origin `console.example.com:18080` and rejected with 403. `$http_host` preserves the Host byte-for-byte.

Verified live: browser-identical handshake (Origin with port) now upgrades to 101 with a working PTY; a foreign Origin still gets 403; REST/SSE unchanged.