### PR TITLE
console: terminal connects on explicit click (not on tab open)

### DIFF
--- a/console/src/Terminal.tsx
+++ b/console/src/Terminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
@@ -7,10 +7,24 @@ import '@xterm/xterm/css/xterm.css'
 // workspace), streamed over a WebSocket to the /v1/sandboxes/{id}/terminal
 // endpoint. Protocol: BINARY frames carry keystrokes (client→server) and shell
 // output (server→client); a TEXT frame `{"resize":{cols,rows}}` reports size.
+//
+// The shell starts only on an explicit click — never on tab open. A live
+// session holds the sandbox awake (it can't idle-sleep), so opening one must
+// be a deliberate act, not a side effect of rendering the tab.
 export function SandboxTerminal({ sandboxId }: { sandboxId: string }) {
   const host = useRef<HTMLDivElement>(null)
+  // 0 = no session requested yet; each increment opens a fresh shell.
+  const [session, setSession] = useState(0)
+  const [status, setStatus] = useState<'idle' | 'connecting' | 'live' | 'closed'>('idle')
+
+  // Switching sandboxes resets to the not-connected state.
+  useEffect(() => {
+    setSession(0)
+    setStatus('idle')
+  }, [sandboxId])
 
   useEffect(() => {
+    if (session === 0) return
     const el = host.current
     if (!el) return
 
@@ -35,10 +49,10 @@ export function SandboxTerminal({ sandboxId }: { sandboxId: string }) {
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ resize: { cols: term.cols, rows: term.rows } }))
     }
 
-    ws.onopen = () => { term.focus(); sendResize() }
+    ws.onopen = () => { setStatus('live'); term.focus(); sendResize() }
     ws.onmessage = (e) => term.write(new Uint8Array(e.data as ArrayBuffer))
-    ws.onclose = () => term.write('\r\n\x1b[90m[ session closed ]\x1b[0m\r\n')
-    ws.onerror = () => term.write('\r\n\x1b[31m[ connection error ]\x1b[0m\r\n')
+    ws.onclose = () => { setStatus('closed'); term.write('\r\n\x1b[90m[ session closed ]\x1b[0m\r\n') }
+    ws.onerror = () => { setStatus('closed'); term.write('\r\n\x1b[31m[ connection error ]\x1b[0m\r\n') }
 
     const inputSub = term.onData((d) => { if (ws.readyState === WebSocket.OPEN) ws.send(enc.encode(d)) })
     const ro = new ResizeObserver(() => sendResize())
@@ -47,10 +61,42 @@ export function SandboxTerminal({ sandboxId }: { sandboxId: string }) {
     return () => {
       inputSub.dispose()
       ro.disconnect()
+      // Detach handlers first so this deliberate teardown (unmount / sandbox
+      // switch) doesn't flash the "closed" state.
+      ws.onclose = null
+      ws.onerror = null
       ws.close()
       term.dispose()
     }
-  }, [sandboxId])
+  }, [sandboxId, session])
 
-  return <div ref={host} style={{ height: 500, width: '100%', background: '#0a0d14', padding: 8, borderRadius: 8, overflow: 'hidden' }} />
+  const overlayVisible = status === 'idle' || status === 'closed'
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <div ref={host} style={{ height: 500, width: '100%', background: '#0a0d14', padding: 8, borderRadius: 8, overflow: 'hidden' }} />
+      {overlayVisible && (
+        <div
+          style={{
+            position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column',
+            alignItems: 'center', justifyContent: 'center', gap: 10,
+            background: status === 'idle' ? '#0a0d14' : 'rgba(10,13,20,0.85)', borderRadius: 8,
+          }}
+        >
+          <button
+            onClick={() => { setStatus('connecting'); setSession((s) => s + 1) }}
+            style={{
+              padding: '10px 22px', borderRadius: 8, border: '1px solid #2c374d',
+              background: '#1a2233', color: '#c6d0de', fontSize: 14, cursor: 'pointer',
+            }}
+          >
+            {status === 'idle' ? 'Open terminal' : 'Reconnect'}
+          </button>
+          <span style={{ color: '#5c6a80', fontSize: 12, maxWidth: 380, textAlign: 'center' }}>
+            Starts an interactive shell inside the sandbox. The sandbox stays awake while the session is open.
+          </span>
+        </div>
+      )}
+    </div>
+  )
 }


### PR DESCRIPTION
Rendering the terminal tab auto-opened a WebSocket, spawning a PTY shell and holding the sandbox awake (live sessions block idle-sleep) without any deliberate user action. The shell now starts only from an explicit **Open terminal** button; after the session ends a **Reconnect** overlay appears. A caption notes the sandbox stays awake while connected. Switching sandboxes resets to the not-connected state.

(The endpoint itself was already gated — auth + same-origin — this is about not spending a shell/wakeup on a render.)