### PR TITLE
readme: CTAs for release news + Cloud waitlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@
 
 ---
 
+<h3 align="center">📣 Stay in the loop</h3>
+
+<p align="center">
+  Self-hosting is <b>MIT and free, forever</b> — <code>git clone</code> and you're done.<br/>
+  Want the <b>1.0 release + occasional product updates</b>, or a <b>managed cloud</b> so you don't run the box yourself? Two links:
+</p>
+
+<p align="center">
+  <a href="https://sandboxd.io/?news=1"><img alt="Get 1.0 + release news" src="https://img.shields.io/badge/%F0%9F%93%AC%20Get%201.0%20%2B%20release%20news-subscribe-0a0a0a?style=for-the-badge"></a>
+  &nbsp;
+  <a href="https://sandboxd.io/?waitlist=cloud"><img alt="sandboxd Cloud waitlist" src="https://img.shields.io/badge/%E2%98%81%EF%B8%8F%20sandboxd%20Cloud-join%20the%20waitlist-ff6b00?style=for-the-badge"></a>
+</p>
+
+<p align="center"><sub>No spam, one-click unsubscribe, and the cloud is <b>optional</b> — the self-hosted engine is always the full product.</sub></p>
+
+---
+
 ## What is sandboxd?
 
 The apps where you type *"build me a todo app"* and a working site appears at its


### PR DESCRIPTION
All the launch traffic lands on the repo, but there was **no way from GitHub** to hear about 1.0 or join the managed-cloud waitlist — that signup only existed on sandboxd.io.

Adds a **'📣 Stay in the loop'** block right after the demo hero, with two badge CTAs:
- **📬 Get 1.0 + release news** → `sandboxd.io/?news=1` (updates list)
- **☁️ sandboxd Cloud — join the waitlist** → `sandboxd.io/?waitlist=cloud`

Both deep-link straight into the signup (banner / modal) via the query-param handlers in sandboxd-docs PR #2. Phrasing leads with **"self-hosting is MIT and free, forever"** and calls the cloud **optional**, so the OSS crowd doesn't read it as an open-core bait-and-switch.

Depends on sandboxd-docs PR #2 being deployed for the deep-links to land on signup; until then the links degrade to a normal homepage load (banner + Cloud button still visible).