### PR TITLE
console(home): explainer + live overview stats on the Apps home

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { api, setOnUnauthorized, App as TApp, Preset, GitCredential } from './api'
+import { api, setOnUnauthorized, App as TApp, Preset, GitCredential, Agent } from './api'
 import { c, font, mono, Card, Btn, StatusPill, Input, navItem } from './design/kit'
 import { PRESET_ICONS } from './design/presetIcons'
 import { STARTERS, STARTER_ICONS } from './design/starters'
@@ -164,10 +164,12 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
   const [creds, setCreds] = useState<GitCredential[]>([])
   const [busy, setBusy] = useState(false)
   const [sbStatus, setSbStatus] = useState<Record<string, string>>({})
+  const [agents, setAgents] = useState<Agent[]>([])
 
   useEffect(() => {
     api.listPresets().then(setPresets).catch(() => {})
     api.listGitCredentials().then(setCreds).catch(() => {})
+    api.getAgents().then(setAgents).catch(() => {})
   }, [])
   useEffect(() => {
     Promise.all(apps.filter((a) => a.current_sandbox_id).map(async (a) => {
@@ -205,10 +207,34 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
     <div onClick={() => setMode(m)} className="dc-hoverborder" data-testid={`mode-${m}`} style={{ padding: '6px 12px', fontSize: 12.5, borderRadius: 7, cursor: 'pointer', border: `1px solid ${mode === m ? c.faint : c.border}`, color: mode === m ? c.fg : c.muted, background: mode === m ? c.panel2 : 'transparent' }}>{label}</div>
   )
 
+  // Live overview — all real (no fabricated time-series/graphs). "asleep" = apps
+  // not currently serving (stopped/sleeping/no sandbox yet); they wake on request.
+  const live = apps.filter((a) => sbStatus[a.id] === 'running').length
+  const connected = agents.filter((a) => a.status === 'connected').length
+  const tiles: { n: string | number; label: string; tone: string; dot?: string }[] = [
+    { n: apps.length, label: 'apps', tone: c.fg },
+    { n: live, label: 'live', tone: c.good, dot: live ? c.good : undefined },
+    { n: Math.max(0, apps.length - live), label: 'asleep', tone: c.muted },
+    { n: `${connected}/${agents.length}`, label: 'agents', tone: connected ? c.fg : c.warn },
+  ]
+
   return (
     <div style={{ maxWidth: 920, margin: '0 auto', padding: '36px 40px 80px' }}>
-      <h1 style={{ fontFamily: font.display, fontSize: 24, fontWeight: 700, margin: '0 0 4px' }}>Apps</h1>
-      <p style={{ color: c.muted, margin: '0 0 24px' }}>Each app runs isolated in its own sandbox with a live preview URL.</p>
+      <h1 style={{ fontFamily: font.display, fontSize: 24, fontWeight: 700, margin: '0 0 6px' }}>Apps</h1>
+      <p style={{ color: c.muted, margin: '0 0 18px', maxWidth: 580 }}>Each app runs isolated in its own sandbox with a live preview URL — an AI agent builds it, you own it. Idle apps sleep and wake on request.</p>
+
+      {/* At-a-glance overview: real, live counts pulled from the API. */}
+      <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 26 }} data-testid="overview-stats">
+        {tiles.map((t) => (
+          <Card key={t.label} style={{ padding: '12px 16px', minWidth: 92, display: 'flex', flexDirection: 'column', gap: 3 }}>
+            <span style={{ fontFamily: font.display, fontSize: 26, fontWeight: 700, lineHeight: 1, color: t.tone }}>{t.n}</span>
+            <span style={{ ...mono, fontSize: 11, letterSpacing: '.04em', color: c.muted, textTransform: 'uppercase', display: 'flex', alignItems: 'center', gap: 5 }}>
+              {t.dot && <span style={{ width: 6, height: 6, borderRadius: '50%', background: t.dot }} />}
+              {t.label}
+            </span>
+          </Card>
+        ))}
+      </div>
 
       <Card style={{ padding: 16, marginBottom: 28 }}>
         <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
@@ -277,7 +303,14 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
       </Card>
 
       {apps.length === 0 ? (
-        <p style={{ color: c.muted2 }}>No apps yet — create one above to get started.</p>
+        <Card style={{ padding: '22px 20px', textAlign: 'center' }} data-testid="apps-empty">
+          <div style={{ fontFamily: font.display, fontWeight: 600, fontSize: 15, marginBottom: 6 }}>No apps yet</div>
+          <div style={{ color: c.muted, fontSize: 13, lineHeight: 1.55, maxWidth: 440, margin: '0 auto' }}>
+            Create one above from a blank template, a starter, or a Git repo — or browse the{' '}
+            <a onClick={goStore} style={{ color: c.link, cursor: 'pointer', textDecoration: 'none' }}>App Store</a>{' '}
+            to launch a ready-made app in one click. Whatever you make gets its own isolated sandbox and a live preview URL.
+          </div>
+        </Card>
       ) : (
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(270px,1fr))', gap: 14 }} data-testid="app-list">
           {apps.map((a) => (

--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -154,7 +154,6 @@ const PRESET_META: Record<string, { short: string; tag: string }> = {
 
 function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; reload: () => void; onOpen: (id: string) => void; onError: (m: string) => void; goStore: () => void }) {
   const [name, setName] = useState('')
-  const [mode, setMode] = useState<'template' | 'starter' | 'git'>('template')
   const [starter, setStarter] = useState('')
   const [preset, setPreset] = useState('')
   const [presets, setPresets] = useState<Preset[]>([])
@@ -163,8 +162,14 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
   const [credId, setCredId] = useState('')
   const [creds, setCreds] = useState<GitCredential[]>([])
   const [busy, setBusy] = useState(false)
-  const [sbStatus, setSbStatus] = useState<Record<string, string>>({})
+  const [sbInfo, setSbInfo] = useState<Record<string, { status: string; url?: string }>>({})
   const [agents, setAgents] = useState<Agent[]>([])
+  // Progressive disclosure: the simple path (name → create) shows first; the
+  // power options (stack / git / starter) reveal only when asked for.
+  const [showStack, setShowStack] = useState(false)
+  const [showGit, setShowGit] = useState(false)
+  const [showStarter, setShowStarter] = useState(false)
+  const [creating, setCreating] = useState(false) // returning users open the form via "+ New app"
 
   useEffect(() => {
     api.listPresets().then(setPresets).catch(() => {})
@@ -173,43 +178,45 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
   }, [])
   useEffect(() => {
     Promise.all(apps.filter((a) => a.current_sandbox_id).map(async (a) => {
-      try { const s = await api.getSandbox(a.current_sandbox_id as string); return [a.id, s.status] as const } catch { return [a.id, 'unknown'] as const }
-    })).then((p) => setSbStatus(Object.fromEntries(p)))
+      try { const s = await api.getSandbox(a.current_sandbox_id as string); return [a.id, { status: s.status, url: s.preview?.url }] as const }
+      catch { return [a.id, { status: 'unknown' }] as const }
+    })).then((p) => setSbInfo(Object.fromEntries(p)))
   }, [apps])
 
   const create = async () => {
-    if (mode === 'git' && !repo.trim()) { onError('Enter a repo URL'); return }
-    if (mode === 'starter' && !starter) { onError('Pick a starter'); return }
-    const pick = STARTERS.find((s) => s.id === starter)
+    const useGit = showGit && !!repo.trim()
+    const pick = starter ? STARTERS.find((s) => s.id === starter) : undefined
     // No forced naming: derive a sensible default (from the repo/starter, else a
     // short slug) when the field is blank. Renameable anytime from the app header.
     const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '').slice(0, 40)
-    const derived = mode === 'git' && repo.trim() ? slug(repo.trim().replace(/\.git$/, '').split('/').pop() || '')
-      : mode === 'starter' && pick ? slug(pick.id) : ''
+    const derived = useGit ? slug(repo.trim().replace(/\.git$/, '').split('/').pop() || '')
+      : pick ? slug(pick.id) : ''
     const finalName = name.trim() || derived || `app-${Math.random().toString(36).slice(2, 6)}`
     setBusy(true)
     try {
       const a = await api.createApp({
         name: finalName,
-        runtime_preset: mode === 'template' && preset ? preset : undefined,
-        git: mode === 'git' ? { repo_url: repo.trim(), branch: branch.trim() || 'main', ...(credId ? { credential_id: credId } : {}) } // no credId → public tokenless clone
-          : mode === 'starter' && pick ? { repo_url: `https://github.com/${pick.repo}`, branch: pick.branch } // public → tokenless
+        runtime_preset: !useGit && !pick && preset ? preset : undefined, // no stack chosen → auto-detected
+        git: useGit ? { repo_url: repo.trim(), branch: branch.trim() || 'main', ...(credId ? { credential_id: credId } : {}) } // no credId → public tokenless clone
+          : pick ? { repo_url: `https://github.com/${pick.repo}`, branch: pick.branch } // public → tokenless
           : undefined,
       })
       // Zero-friction: boot the sandbox right away so the app is ready to use.
       // If it fails, the app view still offers a Create-sandbox retry.
       try { await api.createAppSandbox(a.id, {}) } catch { /* app exists; retry from the app view */ }
-      setName(''); setRepo(''); reload(); onOpen(a.id)
+      setName(''); setRepo(''); setCreating(false); reload(); onOpen(a.id)
     } catch (e) { onError((e as Error).message) } finally { setBusy(false) }
   }
 
-  const modeChip = (m: 'template' | 'starter' | 'git', label: string) => (
-    <div onClick={() => setMode(m)} className="dc-hoverborder" data-testid={`mode-${m}`} style={{ padding: '6px 12px', fontSize: 12.5, borderRadius: 7, cursor: 'pointer', border: `1px solid ${mode === m ? c.faint : c.border}`, color: mode === m ? c.fg : c.muted, background: mode === m ? c.panel2 : 'transparent' }}>{label}</div>
+  const secBtn = (label: string, active: boolean, onClick: () => void) => (
+    <div onClick={onClick} className="dc-hoverborder" style={{ padding: '7px 13px', fontSize: 12.5, borderRadius: 7, cursor: 'pointer', border: `1px solid ${active ? c.faint : c.border}`, color: active ? c.fg : c.muted, background: active ? c.panel2 : 'transparent' }}>{label}</div>
   )
 
   // Live overview — all real (no fabricated time-series/graphs). "asleep" = apps
   // not currently serving (stopped/sleeping/no sandbox yet); they wake on request.
-  const live = apps.filter((a) => sbStatus[a.id] === 'running').length
+  const runningApps = apps.filter((a) => sbInfo[a.id]?.status === 'running')
+  const otherApps = apps.filter((a) => sbInfo[a.id]?.status !== 'running')
+  const live = runningApps.length
   const connected = agents.filter((a) => a.status === 'connected').length
   const tiles: { n: string | number; label: string; tone: string; dot?: string }[] = [
     { n: apps.length, label: 'apps', tone: c.fg },
@@ -217,6 +224,7 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
     { n: Math.max(0, apps.length - live), label: 'asleep', tone: c.muted },
     { n: `${connected}/${agents.length}`, label: 'agents', tone: connected ? c.fg : c.warn },
   ]
+  const showForm = creating || apps.length === 0
 
   return (
     <div style={{ maxWidth: 920, margin: '0 auto', padding: '36px 40px 80px' }}>
@@ -236,100 +244,149 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
         ))}
       </div>
 
-      <Card style={{ padding: 16, marginBottom: 28 }}>
-        <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
-          <Input mono value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && create()} placeholder="name — optional, rename anytime" style={{ flex: 1, fontSize: 13 }} data-testid="app-name" />
-          <Btn variant="primary" disabled={busy || (mode === 'starter' && !starter)} onClick={create} style={{ padding: '9px 18px', fontSize: 13 }}>{mode === 'starter' ? 'Create from starter' : 'Create app'}</Btn>
-        </div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-          {modeChip('template', 'Blank template')}
-          {modeChip('starter', 'Starter project')}
-          {modeChip('git', 'Import from Git')}
-          <span style={{ color: c.muted2, fontSize: 12, marginLeft: 'auto' }}>Want a ready-made app? Browse the <a onClick={goStore} style={{ color: c.link, cursor: 'pointer', textDecoration: 'none' }}>App Store</a>.</span>
-        </div>
-
-        {mode === 'starter' ? (
-          <div data-testid="starter-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(212px,1fr))', gap: 10, marginTop: 14 }}>
-            {STARTERS.map((s) => {
-              const active = starter === s.id
+      {/* RUNNING NOW — the live app is the hero, not a tiny pill in the top bar. */}
+      {runningApps.length > 0 && (
+        <div style={{ marginBottom: 28 }} data-testid="running-now">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 10 }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', background: c.good }} />
+            <span style={{ fontFamily: font.display, fontWeight: 700, fontSize: 14 }}>Running now</span>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(240px,1fr))', gap: 12 }}>
+            {runningApps.map((a) => {
+              const url = sbInfo[a.id]?.url
               return (
-                <div key={s.id} data-testid={`starter-${s.id}`} onClick={() => setStarter(active ? '' : s.id)} className="dc-hoverborder"
-                  style={{ position: 'relative', display: 'flex', gap: 10, padding: '12px 13px', borderRadius: 10, cursor: 'pointer', border: `1px solid ${active ? c.ink : c.border}`, background: active ? c.panel2 : c.panel, boxShadow: active ? `inset 0 0 0 1px ${c.ink}` : 'none' }}>
-                  {active && <span style={{ position: 'absolute', top: 8, right: 8, width: 15, height: 15, borderRadius: '50%', background: c.ink, color: '#fff', fontSize: 9, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</span>}
-                  <span className="prov-ico" style={{ width: 24, height: 24, flexShrink: 0, marginTop: 1 }} dangerouslySetInnerHTML={{ __html: STARTER_ICONS[s.tech] || '' }} />
-                  <div style={{ minWidth: 0 }}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                      <span style={{ fontFamily: font.display, fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
-                      {s.stars && <span style={{ ...mono, fontSize: 10, color: c.muted2, flexShrink: 0 }}>★{s.stars}</span>}
+                <Card key={a.id} style={{ padding: 14, borderColor: c.good }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+                    <span style={{ width: 7, height: 7, borderRadius: '50%', background: c.good, flexShrink: 0 }} />
+                    <span style={{ ...mono, fontWeight: 500, fontSize: 14, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{a.name}</span>
+                    <span style={{ ...mono, fontSize: 10, color: c.good, letterSpacing: '.05em' }}>LIVE</span>
+                  </div>
+                  {url && <div style={{ ...mono, fontSize: 11, color: c.muted2, marginBottom: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{url.replace(/^https?:\/\//, '')}</div>}
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <Btn variant="primary" onClick={() => url ? window.open(url, '_blank') : onOpen(a.id)} style={{ padding: '7px 14px', fontSize: 12.5 }}>Open ↗</Btn>
+                    <Btn onClick={() => onOpen(a.id)} style={{ padding: '7px 12px', fontSize: 12.5 }}>Manage</Btn>
+                  </div>
+                </Card>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* CREATE — simple by default (name → create, stack auto-detected); the
+          power paths (stack / git / starter) reveal only on demand. */}
+      {showForm && (
+        <Card style={{ padding: 16, marginBottom: 28 }}>
+          {apps.length === 0 && <div style={{ fontFamily: font.display, fontWeight: 700, fontSize: 16, marginBottom: 10 }}>Build an app you own</div>}
+          <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
+            <Input mono value={name} onChange={(e) => setName(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && create()} placeholder="Describe or name your app…" style={{ flex: 1, fontSize: 13 }} data-testid="app-name" />
+            <Btn variant="primary" disabled={busy} onClick={create} style={{ padding: '9px 18px', fontSize: 13 }}>Create app</Btn>
+          </div>
+
+          {/* optional stack picker — hidden by default */}
+          <div onClick={() => setShowStack((v) => !v)} className="dc-hoverink" data-testid="stack-toggle" style={{ ...mono, fontSize: 12, color: c.muted, cursor: 'pointer', userSelect: 'none' }}>
+            {showStack ? '▾' : '▸'} Choose a stack <span style={{ color: c.muted2 }}>(optional — auto-detected by default)</span>
+          </div>
+          {showStack && (
+            <div data-testid="app-preset" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(158px,1fr))', gap: 10, marginTop: 12 }}>
+              {presets.map((p) => {
+                const meta = PRESET_META[p.id] || { short: p.label, tag: p.description }
+                const active = preset === p.id
+                return (
+                  <div key={p.id} data-testid={`preset-${p.id}`} onClick={() => setPreset(active ? '' : p.id)} className="dc-hoverborder"
+                    style={{ position: 'relative', display: 'flex', flexDirection: 'column', gap: 8, padding: '13px 13px 12px', borderRadius: 10, cursor: 'pointer', border: `1px solid ${active ? c.ink : c.border}`, background: active ? c.panel2 : c.panel, boxShadow: active ? `inset 0 0 0 1px ${c.ink}` : 'none' }}>
+                    {active && <span style={{ position: 'absolute', top: 9, right: 9, width: 16, height: 16, borderRadius: '50%', background: c.ink, color: '#fff', fontSize: 10, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</span>}
+                    <span className="prov-ico" style={{ width: 26, height: 26 }} dangerouslySetInnerHTML={{ __html: PRESET_ICONS[p.id] || '' }} />
+                    <div>
+                      <div style={{ fontFamily: font.display, fontWeight: 600, fontSize: 13.5 }}>{meta.short}</div>
+                      <div style={{ color: c.muted2, fontSize: 11.5, lineHeight: 1.35, marginTop: 1 }}>{meta.tag}</div>
                     </div>
-                    <div style={{ color: c.muted2, fontSize: 11, lineHeight: 1.35, marginTop: 2 }}>{s.blurb}</div>
-                    <div style={{ ...mono, fontSize: 10, color: c.faint, marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.repo}</div>
                   </div>
-                </div>
-              )
-            })}
-          </div>
-        ) : mode === 'template' ? (
-          <div data-testid="app-preset" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(158px,1fr))', gap: 10, marginTop: 14 }}>
-            {presets.map((p) => {
-              const meta = PRESET_META[p.id] || { short: p.label, tag: p.description }
-              const active = preset === p.id
-              return (
-                <div key={p.id} data-testid={`preset-${p.id}`} onClick={() => setPreset(active ? '' : p.id)} className="dc-hoverborder"
-                  style={{ position: 'relative', display: 'flex', flexDirection: 'column', gap: 8, padding: '13px 13px 12px', borderRadius: 10, cursor: 'pointer', border: `1px solid ${active ? c.ink : c.border}`, background: active ? c.panel2 : c.panel, boxShadow: active ? `inset 0 0 0 1px ${c.ink}` : 'none' }}>
-                  {active && <span style={{ position: 'absolute', top: 9, right: 9, width: 16, height: 16, borderRadius: '50%', background: c.ink, color: '#fff', fontSize: 10, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</span>}
-                  <span className="prov-ico" style={{ width: 26, height: 26 }} dangerouslySetInnerHTML={{ __html: PRESET_ICONS[p.id] || '' }} />
-                  <div>
-                    <div style={{ fontFamily: font.display, fontWeight: 600, fontSize: 13.5 }}>{meta.short}</div>
-                    <div style={{ color: c.muted2, fontSize: 11.5, lineHeight: 1.35, marginTop: 1 }}>{meta.tag}</div>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        ) : (
-          <div style={{ display: 'flex', gap: 8, marginTop: 14, flexWrap: 'wrap' }}>
-            <Input mono value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="https://github.com/user/repo.git" style={{ flex: 1, minWidth: 220, fontSize: 12.5 }} data-testid="git-repo-url" />
-            <Input mono value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="branch" style={{ width: 120, fontSize: 12.5 }} data-testid="git-branch" />
-            <select value={credId} onChange={(e) => setCredId(e.target.value)} data-testid="git-cred" style={{ background: c.bg, border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 10px', color: c.fg, fontSize: 12.5, fontFamily: font.sans }}>
-              <option value="">Public repo — no credential</option>
-              {creds.map((g) => <option key={g.id} value={g.id}>{g.name}</option>)}
-            </select>
-          </div>
-        )}
-        {mode === 'git' && creds.length === 0 && (
-          <div style={{ marginTop: 8, fontSize: 12, color: c.muted }} data-testid="git-no-creds"><b>Public repos import with no credential.</b> For a <b>private</b> repo, add a personal access token in <b>Settings → Git credentials</b>.</div>
-        )}
-      </Card>
+                )
+              })}
+            </div>
+          )}
 
-      {apps.length === 0 ? (
-        <Card style={{ padding: '22px 20px', textAlign: 'center' }} data-testid="apps-empty">
-          <div style={{ fontFamily: font.display, fontWeight: 600, fontSize: 15, marginBottom: 6 }}>No apps yet</div>
-          <div style={{ color: c.muted, fontSize: 13, lineHeight: 1.55, maxWidth: 440, margin: '0 auto' }}>
-            Create one above from a blank template, a starter, or a Git repo — or browse the{' '}
-            <a onClick={goStore} style={{ color: c.link, cursor: 'pointer', textDecoration: 'none' }}>App Store</a>{' '}
-            to launch a ready-made app in one click. Whatever you make gets its own isolated sandbox and a live preview URL.
+          {/* secondary paths — off to the side, not shoved up front */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginTop: 16, paddingTop: 14, borderTop: `1px solid ${c.border}` }}>
+            <span style={{ color: c.muted2, fontSize: 12, marginRight: 2 }}>or</span>
+            {secBtn('Import from Git', showGit, () => { setShowGit((v) => !v); setShowStarter(false) })}
+            {secBtn('Start from a starter', showStarter, () => { setShowStarter((v) => !v); setShowGit(false) })}
+            {secBtn('Browse App Store', false, goStore)}
           </div>
-        </Card>
-      ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(270px,1fr))', gap: 14 }} data-testid="app-list">
-          {apps.map((a) => (
-            <Card key={a.id} style={{ padding: 16, cursor: 'pointer' }} >
-              <div className="dc-hoverborder" onClick={() => onOpen(a.id)} data-testid="app-card">
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-                  <span style={{ ...mono, fontWeight: 500, fontSize: 14 }}>{a.name}</span>
-                  {a.current_sandbox_id ? <StatusPill status={sbStatus[a.id]} /> : <StatusPill status={undefined} />}
-                </div>
-                <div style={{ color: c.muted, fontSize: 12.5, marginBottom: 12 }}>{a.description || a.id}</div>
-                <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
-                  {(a.tags || []).slice(0, 3).map((t) => (
-                    <span key={t} style={{ ...mono, fontSize: 10.5, color: c.muted, background: c.panel2, border: `1px solid ${c.border}`, borderRadius: 5, padding: '2px 7px' }}>{t}</span>
-                  ))}
-                  <span style={{ marginLeft: 'auto', color: c.link, fontSize: 12 }}>Open →</span>
-                </div>
+
+          {showGit && (
+            <>
+              <div style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+                <Input mono value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="https://github.com/user/repo.git" style={{ flex: 1, minWidth: 220, fontSize: 12.5 }} data-testid="git-repo-url" />
+                <Input mono value={branch} onChange={(e) => setBranch(e.target.value)} placeholder="branch" style={{ width: 120, fontSize: 12.5 }} data-testid="git-branch" />
+                <select value={credId} onChange={(e) => setCredId(e.target.value)} data-testid="git-cred" style={{ background: c.bg, border: `1px solid ${c.border2}`, borderRadius: 7, padding: '8px 10px', color: c.fg, fontSize: 12.5, fontFamily: font.sans }}>
+                  <option value="">Public repo — no credential</option>
+                  {creds.map((g) => <option key={g.id} value={g.id}>{g.name}</option>)}
+                </select>
               </div>
-            </Card>
-          ))}
+              {creds.length === 0 && (
+                <div style={{ marginTop: 8, fontSize: 12, color: c.muted }} data-testid="git-no-creds"><b>Public repos import with no credential.</b> For a <b>private</b> repo, add a personal access token in <b>Settings → Git credentials</b>.</div>
+              )}
+            </>
+          )}
+
+          {showStarter && (
+            <div data-testid="starter-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(212px,1fr))', gap: 10, marginTop: 12 }}>
+              {STARTERS.map((s) => {
+                const active = starter === s.id
+                return (
+                  <div key={s.id} data-testid={`starter-${s.id}`} onClick={() => setStarter(active ? '' : s.id)} className="dc-hoverborder"
+                    style={{ position: 'relative', display: 'flex', gap: 10, padding: '12px 13px', borderRadius: 10, cursor: 'pointer', border: `1px solid ${active ? c.ink : c.border}`, background: active ? c.panel2 : c.panel, boxShadow: active ? `inset 0 0 0 1px ${c.ink}` : 'none' }}>
+                    {active && <span style={{ position: 'absolute', top: 8, right: 8, width: 15, height: 15, borderRadius: '50%', background: c.ink, color: '#fff', fontSize: 9, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>✓</span>}
+                    <span className="prov-ico" style={{ width: 24, height: 24, flexShrink: 0, marginTop: 1 }} dangerouslySetInnerHTML={{ __html: STARTER_ICONS[s.tech] || '' }} />
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <span style={{ fontFamily: font.display, fontWeight: 600, fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
+                        {s.stars && <span style={{ ...mono, fontSize: 10, color: c.muted2, flexShrink: 0 }}>★{s.stars}</span>}
+                      </div>
+                      <div style={{ color: c.muted2, fontSize: 11, lineHeight: 1.35, marginTop: 2 }}>{s.blurb}</div>
+                      <div style={{ ...mono, fontSize: 10, color: c.faint, marginTop: 3, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.repo}</div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </Card>
+      )}
+
+      {/* YOUR APPS — the asleep/idle ones; running apps live in "Running now". */}
+      {apps.length > 0 && (
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 12 }}>
+            <span style={{ fontFamily: font.display, fontWeight: 700, fontSize: 14 }}>Your apps</span>
+            <div style={{ flex: 1 }} />
+            <Btn variant="primary" onClick={() => setCreating((v) => !v)} style={{ padding: '7px 14px', fontSize: 12.5 }} data-testid="new-app-toggle">{creating ? 'Close' : '+ New app'}</Btn>
+          </div>
+          {otherApps.length === 0 ? (
+            <p style={{ color: c.muted2, fontSize: 13 }}>Every app is running — see “Running now” above.</p>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(270px,1fr))', gap: 14 }} data-testid="app-list">
+              {otherApps.map((a) => (
+                <Card key={a.id} style={{ padding: 16, cursor: 'pointer' }}>
+                  <div className="dc-hoverborder" onClick={() => onOpen(a.id)} data-testid="app-card">
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                      <span style={{ ...mono, fontWeight: 500, fontSize: 14 }}>{a.name}</span>
+                      <StatusPill status={a.current_sandbox_id ? sbInfo[a.id]?.status : undefined} />
+                    </div>
+                    <div style={{ color: c.muted, fontSize: 12.5, marginBottom: 12 }}>{a.description || a.id}</div>
+                    <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      {(a.tags || []).slice(0, 3).map((t) => (
+                        <span key={t} style={{ ...mono, fontSize: 10.5, color: c.muted, background: c.panel2, border: `1px solid ${c.border}`, borderRadius: 5, padding: '2px 7px' }}>{t}</span>
+                      ))}
+                      <span style={{ marginLeft: 'auto', color: c.link, fontSize: 12 }}>Open →</span>
+                    </div>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
The console home was a create form + a plain list — it never told a first-time visitor **what sandboxd is** or gave any at-a-glance status. This is the first thing people see, so it should orient and inform.

**Adds:**
- a one-line explainer under the heading (isolated sandbox · AI agent builds it · you own it · sleeps/wakes)
- a row of **real, live stat tiles** — apps / live / asleep / agents connected — pulled straight from the API (no fabricated time-series or graphs; sandboxd stores no metric history, so I deliberately didn't fake CPU/mem charts)
- a warmer empty state that guides toward create / App Store instead of a bare 'no apps' line

Cheap: reuses `apps` + `sbStatus` the screen already computes; adds one `getAgents()` on mount. Verified: tsc clean, normal + shares the demo build path, new home bundled, deployed to the live console.

Design matches the existing brutalist-mono system (Card, `c.*` tokens, display/mono fonts) — no new palette introduced.