### PR TITLE
readme: affiliate disclosure above the deploy links

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ sandboxd needs one Linux server with Docker — nothing else. Grab a server
 below (2 vCPU / 4 GB is plenty to start), paste our
 [cloud-init file](deploy/cloud-init.yaml) at creation, and it installs itself.
 
+> **Disclosure:** we earn a referral commission when you sign up through the
+> provider links below, at no additional cost to you. It helps fund sandboxd's
+> development.
+
 [![Deploy on Vultr](https://img.shields.io/badge/Deploy%20on-Vultr-007BFC?logo=vultr&logoColor=white&style=for-the-badge)](https://www.vultr.com/?ref=9912150)
 
 <!-- ENABLE THESE AS EACH AFFILIATE LINK ARRIVES (uncomment + replace placeholder):
@@ -200,9 +204,6 @@ curl -fsSL https://raw.githubusercontent.com/tastyeffectco/sandboxd/main/deploy/
 ```
 
 Full per-provider walkthrough: [deploy/DEPLOY.md](deploy/DEPLOY.md).
-
-> *Some links above are referral links — they cost you nothing and support
-> sandboxd's development.*
 
 ## What you get
 


### PR DESCRIPTION
DigitalOcean's affiliate program (and FTC guidance) require the referral disclosure to appear **before** the affiliate links, with clear wording. The README had a live Vultr referral link and only a note *after* the links.

- Moves the disclosure to sit **directly above** the provider badges.
- Uses DO-approved phrasing: *'we earn a referral commission when you sign up through the provider links below, at no additional cost to you.'*
- Covers the live Vultr link now and the DigitalOcean badge once its AWIN link is added.

This is the page to send DigitalOcean as an example once merged + live.