### PR TITLE
feat(agent-auth): add direct MiniMax credentials and upstreams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,12 @@ SANDBOXD_OPENCODE_ZEN_PATH=zen
 # SANDBOXD_AGENT_PROXY_URL=http://sandboxd:9100
 # Optional global default model for opencode tasks (e.g. opencode/glm-5).
 # SANDBOXD_OPENCODE_MODEL=
+# MiniMax direct endpoints (a connected MiniMax API key, Settings → AI Agents,
+# is injected by the auth proxy). Global: api.minimax.io; China: api.minimaxi.com.
+# MiniMax-M3 and MiniMax-M2.7 route to the OpenAI-compatible endpoint
+# (/v1); Anthropic-compatible (/anthropic) traffic is also proxied. Pick the
+# China region with SANDBOXD_MINIMAX_REGION=cn_zh (default global_en).
+# SANDBOXD_MINIMAX_REGION=global_en
 
 # ── Console login ────────────────────────────────────────────────────
 # The web console (docker compose --profile console) is protected by an

--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -522,7 +522,7 @@ function AgentChat({ sb, onError, toast, refresh }: { sb: Sandbox | null; onErro
           <select value={model} onChange={(e) => setModel(e.target.value)} data-testid="task-model" style={selStyle}>
             <option value="">Default model</option>
             {agent === 'claude-code' && <><option value="sonnet">Sonnet</option><option value="opus">Opus</option><option value="haiku">Haiku</option></>}
-            {agent === 'opencode' && <><option value="opencode/glm-5">GLM-5</option><option value="opencode/kimi-k2.6">Kimi K2.6</option><option value="opencode/deepseek-v4-pro">DeepSeek V4 Pro</option><option value="opencode/minimax-m3">MiniMax M3</option></>}
+            {agent === 'opencode' && <><option value="opencode/glm-5">GLM-5</option><option value="opencode/kimi-k2.6">Kimi K2.6</option><option value="opencode/deepseek-v4-pro">DeepSeek V4 Pro</option><option value="opencode/MiniMax-M3">MiniMax M3</option><option value="opencode/MiniMax-M2.7">MiniMax M2.7</option></>}
           </select>
         </div>
       </div>

--- a/console/src/SettingsView.tsx
+++ b/console/src/SettingsView.tsx
@@ -102,12 +102,15 @@ export function SettingsView({ onError, toast }: { onError: (m: string) => void;
           {agents.map((a) => {
             // Codex is disabled for now — its ChatGPT-subscription auth can't be
             // put behind the credential proxy yet (see the note below).
+            // MiniMax is a credential-only provider (no task-agent CLI); it's
+            // connectable here but never appears in the run picker.
             const disabled = a.id === 'codex'
+            const credentialOnly = !a.runnable && a.id !== 'codex'
             return (
             <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 14px', border: `1px solid ${c.border}`, borderRadius: 8, background: c.panel2, marginBottom: 8, opacity: disabled ? 0.6 : 1 }} data-testid={`agent-${a.id}`}>
               <div>
                 <div style={{ fontWeight: 500 }}>{a.label}</div>
-                <div style={{ ...mono, fontSize: 11, color: c.muted2 }}>{disabled ? 'temporarily unavailable' : `${a.installed_state === 'installed' ? 'installed' : 'not installed'}${a.status === 'connected' && a.method ? ` · via ${a.method === 'oauth' ? 'subscription' : 'API key'}` : ''}`}</div>
+                <div style={{ ...mono, fontSize: 11, color: c.muted2 }}>{disabled ? 'temporarily unavailable' : `${a.installed_state === 'installed' ? 'installed' : 'not installed'}${a.status === 'connected' && a.method ? ` · via ${a.method === 'oauth' ? 'subscription' : 'API key'}` : ''}${credentialOnly ? ' · model gateway' : ''}`}</div>
               </div>
               {disabled ? (
                 <span style={{ marginLeft: 'auto' }}><Pill tone="neutral">disabled</Pill></span>
@@ -135,7 +138,7 @@ export function SettingsView({ onError, toast }: { onError: (m: string) => void;
             <span style={{ marginLeft: 'auto', fontSize: 11.5, color: c.muted2 }}>optional — used when a task doesn't pick a model</span>
           </div>
           <div style={{ color: c.muted2, fontSize: 12, lineHeight: 1.5, marginBottom: 10 }}>Paste each agent's own model id (e.g. OpenCode <span style={{ ...mono, fontSize: 11 }}>glm-5</span>, Claude <span style={{ ...mono, fontSize: 11 }}>sonnet</span>). Leave blank for the agent's default — OpenCode with no API key falls back to its free tier (<span style={{ ...mono, fontSize: 11 }}>big-pickle</span>).</div>
-          {agents.filter((a) => a.id !== 'codex').map((a) => (
+          {agents.filter((a) => a.id !== 'codex' && a.runnable).map((a) => (
             <div key={a.id} style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
               <span style={{ width: 130, fontSize: 12.5, color: c.muted }}>{a.label}</span>
               <Input mono value={models[a.id] || ''} onChange={(e) => setModels({ ...models, [a.id]: e.target.value })} disabled={!modelsEditable} placeholder={a.id === 'opencode' ? 'big-pickle (free tier)' : 'agent default'} style={{ width: 260 }} data-testid={`agent-model-${a.id}`} />

--- a/control-plane/cmd/runtimed/opencode.go
+++ b/control-plane/cmd/runtimed/opencode.go
@@ -227,6 +227,39 @@ func zenUpstream() string {
 	return "zen"
 }
 
+// minimaxModels is the set of MiniMax text models routed to a direct MiniMax
+// OpenAI-compatible upstream instead of the OpenCode Zen path. These model ids
+// are passed verbatim to the proxy, which injects the connected MiniMax API
+// key and forwards to api.minimax.io/v1 (or api.minimaxi.com/v1 for the China
+// region). Context window, pricing, input modality, cache, and thinking
+// metadata for these models are documented in docs/agent-auth.md.
+var minimaxModels = map[string]bool{
+	"MiniMax-M3":   true,
+	"MiniMax-M2.7": true,
+}
+
+// minimaxUpstream returns the proxy <upstream> segment for a MiniMax model:
+// the global OpenAI-compatible endpoint by default, or the China endpoint when
+// SANDBOXD_MINIMAX_REGION=cn_zh. (The Anthropic-compatible MiniMax endpoints
+// are reachable when an agent sends Anthropic-shaped traffic to the matching
+// minimax-anthropic[|-cn] upstream; opencode uses the OpenAI-compatible one.)
+func minimaxUpstream() string {
+	if r := os.Getenv("SANDBOXD_MINIMAX_REGION"); r == "cn_zh" {
+		return "minimax-cn"
+	}
+	return "minimax"
+}
+
+// opencodeUpstream picks the proxy <upstream> segment for a given bare model id:
+// a MiniMax model routes to its direct MiniMax upstream; anything else keeps the
+// existing Zen path (zen | zengo via SANDBOXD_OPENCODE_ZEN_PATH).
+func opencodeUpstream(id string) string {
+	if minimaxModels[id] {
+		return minimaxUpstream()
+	}
+	return zenUpstream()
+}
+
 // ipBaseURL rewrites a base URL's host to its resolved IP. opencode's Bun
 // runtime rejects a bare single-label hostname (e.g. "sandboxd") in a provider
 // baseURL with "fetch() URL is invalid", so we hand it an IP literal instead.
@@ -250,9 +283,14 @@ func ipBaseURL(raw string) (string, error) {
 // writeOpencodeProxyConfig writes an OPENCODE_CONFIG that routes opencode through
 // the credential-injecting proxy, and returns (config path, model id to pass to
 // --model). It defines ONE custom openai-compatible provider ("proxy") pointing
-// at the proxy's `opencode/<zen-path>` endpoint with a DUMMY key; the proxy holds
+// at the proxy's `opencode/<upstream>` endpoint with a DUMMY key; the proxy holds
 // the real credential and injects it on the wire, so nothing secret lands in the
 // sandbox. The requested model is exposed as `proxy/<id>`.
+//
+// The <upstream> segment is chosen from the model id: MiniMax models
+// (MiniMax-M3 / MiniMax-M2.7) route to a direct MiniMax OpenAI-compatible
+// upstream (the China region is selected with SANDBOXD_MINIMAX_REGION=cn_zh);
+// every other model keeps the existing Zen path (zen | zengo).
 //
 // Returns ("","",nil) when no proxy is configured — the caller then falls back to
 // opencode's own auth/model handling.
@@ -279,7 +317,7 @@ func writeOpencodeProxyConfig(model string) (string, string, error) {
 				"npm":  "@ai-sdk/openai-compatible",
 				"name": "proxy",
 				"options": map[string]any{
-					"baseURL": base + "/opencode/" + zenUpstream(),
+					"baseURL": base + "/opencode/" + opencodeUpstream(id),
 					"apiKey":  dummyKey,
 				},
 				"models": map[string]any{id: map[string]any{"name": id}},

--- a/control-plane/cmd/runtimed/proxyconfig_test.go
+++ b/control-plane/cmd/runtimed/proxyconfig_test.go
@@ -94,3 +94,84 @@ func TestZenUpstream(t *testing.T) {
 		t.Error("default should be zen")
 	}
 }
+
+// A MiniMax model routes the proxy provider at the MiniMax direct upstream
+// (global by default), with the bare MiniMax model id preserved, so the proxy
+// injects the connected MiniMax key and forwards to api.minimax.io/v1.
+func TestWriteOpencodeProxyConfigMiniMaxGlobal(t *testing.T) {
+	t.Setenv("RUNTIMED_ANTHROPIC_PROXY", "http://127.0.0.1:9100")
+	t.Setenv("SANDBOXD_MINIMAX_REGION", "")
+	path, model, err := writeOpencodeProxyConfig("opencode/MiniMax-M3")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer os.Remove(path)
+	if model != "proxy/MiniMax-M3" {
+		t.Errorf("model = %q; want the bare MiniMax id preserved", model)
+	}
+	var cfg struct {
+		Provider map[string]struct {
+			Options struct {
+				BaseURL string `json:"baseURL"`
+			} `json:"options"`
+			Models map[string]any `json:"models"`
+		} `json:"provider"`
+	}
+	b, _ := os.ReadFile(path)
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("config not valid json: %v", err)
+	}
+	p := cfg.Provider["proxy"]
+	if !strings.HasSuffix(p.Options.BaseURL, "/opencode/minimax") {
+		t.Errorf("baseURL = %q; want the proxy's opencode/minimax endpoint", p.Options.BaseURL)
+	}
+	if _, ok := p.Models["MiniMax-M3"]; !ok {
+		t.Errorf("MiniMax model not registered: %+v", p.Models)
+	}
+}
+
+// SANDBOXD_MINIMAX_REGION=cn_zh routes MiniMax at the China upstream.
+func TestWriteOpencodeProxyConfigMiniMaxChina(t *testing.T) {
+	t.Setenv("RUNTIMED_ANTHROPIC_PROXY", "http://127.0.0.1:9100")
+	t.Setenv("SANDBOXD_MINIMAX_REGION", "cn_zh")
+	path, _, err := writeOpencodeProxyConfig("opencode/MiniMax-M2.7")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer os.Remove(path)
+	var cfg struct {
+		Provider map[string]struct {
+			Options struct {
+				BaseURL string `json:"baseURL"`
+			} `json:"options"`
+		} `json:"provider"`
+	}
+	b, _ := os.ReadFile(path)
+	json.Unmarshal(b, &cfg)
+	if !strings.HasSuffix(cfg.Provider["proxy"].Options.BaseURL, "/opencode/minimax-cn") {
+		t.Errorf("baseURL = %q; want the China MiniMax upstream", cfg.Provider["proxy"].Options.BaseURL)
+	}
+}
+
+// A non-MiniMax model still routes through the Zen path (regression guard).
+func TestWriteOpencodeProxyConfigNonMiniMaxKeepsZen(t *testing.T) {
+	t.Setenv("RUNTIMED_ANTHROPIC_PROXY", "http://127.0.0.1:9100")
+	t.Setenv("SANDBOXD_OPENCODE_ZEN_PATH", "zengo")
+	path, _, err := writeOpencodeProxyConfig("opencode/glm-5")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer os.Remove(path)
+	var cfg struct {
+		Provider map[string]struct {
+			Options struct {
+				BaseURL string `json:"baseURL"`
+			} `json:"options"`
+		} `json:"provider"`
+	}
+	b, _ := os.ReadFile(path)
+	json.Unmarshal(b, &cfg)
+	if !strings.HasSuffix(cfg.Provider["proxy"].Options.BaseURL, "/opencode/zengo") {
+		t.Errorf("baseURL = %q; non-MiniMax must keep the Zen path", cfg.Provider["proxy"].Options.BaseURL)
+	}
+}

--- a/control-plane/internal/agentauth/registry.go
+++ b/control-plane/internal/agentauth/registry.go
@@ -13,11 +13,19 @@ type Provider struct {
 	Binary string // the CLI binary name, probed for "installed"
 }
 
-// registry is the fixed set of supported providers (owner-operated mode).
+// registry is the fixed set of supported providers (owner-operated mode). It
+// holds the coding-agent CLIs runtimed can drive AND any credential-only
+// provider whose key the auth proxy injects on the wire (a model gateway that
+// is reached through an agent's proxy path, not run as its own task agent).
 var registry = []Provider{
 	{ID: "opencode", Label: "OpenCode", Binary: "opencode"},
 	{ID: "claude-code", Label: "Claude Code", Binary: "claude"},
 	{ID: "codex", Label: "Codex", Binary: "codex"},
+	// MiniMax is a credential-only provider: the owner connects a MiniMax API
+	// key here, and the auth proxy injects it for the minimax upstreams. It has
+	// no task-agent CLI and is never run by runtimed (Runnable=false), so the
+	// console shows it as a credential-only entry, not a run picker option.
+	{ID: "minimax", Label: "MiniMax", Binary: ""},
 }
 
 // Providers returns a copy of the registry in display order.
@@ -78,6 +86,11 @@ var apiKeyEnv = map[string]string{
 	"claude-code": "ANTHROPIC_API_KEY",
 	"codex":       "OPENAI_API_KEY",
 	"opencode":    "OPENCODE_API_KEY",
+	// MiniMax is a credential-only provider; its key is read from the stored
+	// key file and injected by the auth proxy for the minimax upstreams. No CLI
+	// reads this env var (MiniMax is never run as a task agent), so the name is
+	// advisory only.
+	"minimax": "MINIMAX_API_KEY",
 }
 
 // APIKeyEnv returns the env var name a provider's CLI reads its API key from.

--- a/control-plane/internal/agentauth/store_test.go
+++ b/control-plane/internal/agentauth/store_test.go
@@ -11,14 +11,19 @@ func TestRegistryHasExpectedProviders(t *testing.T) {
 	for _, p := range Providers() {
 		got[p.ID] = p
 	}
-	for _, want := range []string{"opencode", "claude-code", "codex"} {
+	for _, want := range []string{"opencode", "claude-code", "codex", "minimax"} {
 		p, ok := got[want]
 		if !ok {
 			t.Errorf("registry missing %q", want)
 			continue
 		}
-		if p.Binary == "" || p.Label == "" {
-			t.Errorf("provider %q missing binary/label: %+v", want, p)
+		if p.Label == "" {
+			t.Errorf("provider %q missing label: %+v", want, p)
+		}
+		// minimax is a credential-only provider (no task-agent CLI), so it has
+		// no binary; every runnable agent must carry one.
+		if want != "minimax" && p.Binary == "" {
+			t.Errorf("provider %q missing binary: %+v", want, p)
 		}
 	}
 	if _, ok := Get("opencode"); !ok {

--- a/control-plane/internal/api/v1_agents_test.go
+++ b/control-plane/internal/api/v1_agents_test.go
@@ -90,10 +90,21 @@ func TestListAgentsProbeUnknown(t *testing.T) {
 		Providers []map[string]any `json:"providers"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &d)
-	if len(d.Providers) != 3 {
-		t.Fatalf("want 3 providers, got %d", len(d.Providers))
+	if len(d.Providers) != 4 {
+		t.Fatalf("want 4 providers, got %d", len(d.Providers))
 	}
 	for _, p := range d.Providers {
+		// minimax is a credential-only provider with no CLI to probe, so its
+		// installed_state is "unknown" (like a failed probe) — never installed.
+		if p["id"] == "minimax" {
+			if p["installed_state"] != "unknown" {
+				t.Errorf("minimax: installed_state = %v; want unknown", p["installed_state"])
+			}
+			if p["runnable"] != false {
+				t.Errorf("minimax: runnable = %v; want false", p["runnable"])
+			}
+			continue
+		}
 		if p["installed_state"] != "unknown" {
 			t.Errorf("%v: installed_state = %v; want unknown", p["id"], p["installed_state"])
 		}

--- a/control-plane/internal/authproxy/proxy.go
+++ b/control-plane/internal/authproxy/proxy.go
@@ -42,6 +42,27 @@ var upstreams = map[string]string{
 	"openai":    "https://api.openai.com/v1",
 	"zen":       "https://opencode.ai/zen/v1",    // opencode's hosted gateway (pay-as-you-go)
 	"zengo":     "https://opencode.ai/zen/go/v1", // opencode Zen "go" subscription
+	// MiniMax direct endpoints — global (api.minimax.io) and China
+	// (api.minimaxi.com), each in an OpenAI-compatible (/v1) and an
+	// Anthropic-compatible (/anthropic) flavor. Their credential is the
+	// connected MiniMax API key (see credFor), not the carrying agent's own.
+	"minimax":              "https://api.minimax.io/v1",
+	"minimax-cn":           "https://api.minimaxi.com/v1",
+	"minimax-anthropic":    "https://api.minimax.io/anthropic",
+	"minimax-anthropic-cn": "https://api.minimaxi.com/anthropic",
+}
+
+// isMiniMaxUpstream reports whether <upstream> is one of the MiniMax direct
+// endpoints. MiniMax is a credential-only provider: whatever coding agent
+// carries the request, the proxy injects the connected MiniMax API key
+// (Bearer; MiniMax's OpenAI- and Anthropic-compatible endpoints both accept
+// Authorization: Bearer) rather than the agent's own credential.
+func isMiniMaxUpstream(up string) bool {
+	switch up {
+	case "minimax", "minimax-cn", "minimax-anthropic", "minimax-anthropic-cn":
+		return true
+	}
+	return false
 }
 
 // Proxy injects the real provider credential into forwarded requests.
@@ -72,11 +93,10 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	agent, up := segs[0], segs[1]
-	// OpenCode free tier: an unconnected opencode is served by Zen's keyless free
-	// models, which live ONLY on the `zen` endpoint. Force `zen` even if the
-	// operator pinned `zengo` (the go-subscription endpoint carries no free models,
-	// so a free-tier request there fails as "Model … is not supported").
-	if agent == "opencode" && p.store.Method("opencode") == "" {
+	// MiniMax direct endpoints are credential-only — never rewrite them to the
+	// opencode free-tier path (a MiniMax request needs the connected MiniMax key,
+	// never Zen's keyless free models).
+	if !isMiniMaxUpstream(up) && agent == "opencode" && p.store.Method("opencode") == "" {
 		up = "zen"
 	}
 	rest := "/"
@@ -120,6 +140,21 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // credFor returns a header-injector for (agent, upstream) using the agent's
 // stored credential, or ok=false when there's no usable/proxyable credential.
 func (p *Proxy) credFor(agent, up string) (func(http.Header), bool) {
+	// MiniMax direct endpoints are credential-only: regardless of which coding
+	// agent carries the request, the proxy injects the connected MiniMax API key
+	// (Bearer — MiniMax's OpenAI- and Anthropic-compatible endpoints both accept
+	// Authorization: Bearer). The carrying agent's own credential is irrelevant
+	// here; MiniMax has no task-agent CLI of its own.
+	if isMiniMaxUpstream(up) {
+		key := readTrim(filepath.Join(p.store.Dir("minimax"), agentauth.APIKeyFile))
+		if key == "" {
+			return nil, false
+		}
+		return func(h http.Header) {
+			h.Del("X-Api-Key")
+			h.Set("Authorization", "Bearer "+key)
+		}, true
+	}
 	switch p.store.Method(agent) {
 	case "api_key":
 		key := readTrim(filepath.Join(p.store.Dir(agent), agentauth.APIKeyFile))

--- a/control-plane/internal/authproxy/proxy_test.go
+++ b/control-plane/internal/authproxy/proxy_test.go
@@ -220,3 +220,111 @@ func TestCodexNoCredentialStill401(t *testing.T) {
 		t.Fatalf("codex unconnected = %d; want 401 (only opencode has a free tier)", w.Code)
 	}
 }
+
+// MiniMax is a credential-only upstream: the connected MiniMax API key is
+// injected (Bearer) regardless of which carrying agent is in the path, and the
+// global OpenAI-compatible base path (/v1) is preserved.
+func TestMiniMaxInjectsKeyGlobalOpenAI(t *testing.T) {
+	var gotAuth, gotKey, gotPath string
+	stubUpstream(t, "minimax", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotKey, gotPath = r.Header.Get("Authorization"), r.Header.Get("X-Api-Key"), r.URL.Path
+		w.WriteHeader(200)
+	})
+	st := agentauth.NewStore(t.TempDir())
+	writeAPIKey(t, st, "minimax", "minimax-REAL-KEY")
+	p := New(st, nil)
+
+	// Carried by opencode — the agent's own credential is irrelevant here.
+	req := httptest.NewRequest("POST", "/opencode/minimax/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sandboxd-proxy-injected") // the dummy
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status %d; want 200", w.Code)
+	}
+	if gotAuth != "Bearer minimax-REAL-KEY" {
+		t.Errorf("Authorization = %q; want the injected MiniMax key", gotAuth)
+	}
+	if gotKey != "" {
+		t.Errorf("X-Api-Key leaked: %q (MiniMax uses Bearer)", gotKey)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("forwarded path = %q; want /v1/chat/completions (base /v1 preserved)", gotPath)
+	}
+}
+
+// MiniMax with no connected key → 401 (a clear "connect it" error), even when
+// the carrying agent (opencode) would otherwise fall back to its keyless tier.
+func TestMiniMaxNoCredential401(t *testing.T) {
+	stubUpstream(t, "minimax", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	p := New(agentauth.NewStore(t.TempDir()), nil) // nothing connected
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, httptest.NewRequest("POST", "/opencode/minimax/v1/chat/completions", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unconnected minimax = %d; want 401", w.Code)
+	}
+}
+
+// The China region upstream (minimax-cn) hits api.minimaxi.com and carries the
+// same injected key.
+func TestMiniMaxChinaEndpoint(t *testing.T) {
+	var gotAuth, gotPath string
+	stubUpstream(t, "minimax-cn", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+		w.WriteHeader(200)
+	})
+	st := agentauth.NewStore(t.TempDir())
+	writeAPIKey(t, st, "minimax", "minimax-REAL-KEY")
+	p := New(st, nil)
+
+	req := httptest.NewRequest("POST", "/opencode/minimax-cn/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+	if gotAuth != "Bearer minimax-REAL-KEY" {
+		t.Errorf("Authorization = %q; want the injected MiniMax key", gotAuth)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("forwarded path = %q; want /v1/chat/completions", gotPath)
+	}
+}
+
+// The Anthropic-compatible MiniMax endpoint (/anthropic base) is also reached
+// with the Bearer key (MiniMax's anthropic-compatible API accepts Bearer).
+func TestMiniMaxAnthropicEndpointBearer(t *testing.T) {
+	var gotAuth, gotKey, gotPath string
+	stubUpstream(t, "minimax-anthropic", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotKey, gotPath = r.Header.Get("Authorization"), r.Header.Get("X-Api-Key"), r.URL.Path
+		w.WriteHeader(200)
+	})
+	st := agentauth.NewStore(t.TempDir())
+	writeAPIKey(t, st, "minimax", "minimax-REAL-KEY")
+	p := New(st, nil)
+
+	req := httptest.NewRequest("POST", "/opencode/minimax-anthropic/anthropic/v1/messages", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+	if gotAuth != "Bearer minimax-REAL-KEY" {
+		t.Errorf("Authorization = %q; want Bearer (MiniMax anthropic-compat)", gotAuth)
+	}
+	if gotKey != "" {
+		t.Errorf("X-Api-Key set: %q; MiniMax anthropic-compat uses Bearer", gotKey)
+	}
+	if gotPath != "/anthropic/v1/messages" {
+		t.Errorf("forwarded path = %q; want /anthropic/v1/messages (base /anthropic preserved)", gotPath)
+	}
+}
+
+// isMiniMaxUpstream recognizes all four MiniMax direct upstream keys.
+func TestIsMiniMaxUpstream(t *testing.T) {
+	for _, up := range []string{"minimax", "minimax-cn", "minimax-anthropic", "minimax-anthropic-cn"} {
+		if !isMiniMaxUpstream(up) {
+			t.Errorf("%q should be a MiniMax upstream", up)
+		}
+	}
+	for _, up := range []string{"anthropic", "openai", "zen", "zengo", "", "minimaxx"} {
+		if isMiniMaxUpstream(up) {
+			t.Errorf("%q should NOT be a MiniMax upstream", up)
+		}
+	}
+}

--- a/docs/agent-auth.md
+++ b/docs/agent-auth.md
@@ -44,7 +44,8 @@ wire. A task can neither read, exfiltrate, nor clobber the credential.
 Sandbox base URLs are `<proxy>/<agent>/<upstream>/…`; the proxy resolves the
 agent's stored credential for that upstream and injects it. Upstreams:
 `anthropic`, `openai`, `zen` (OpenCode Zen pay-as-you-go), `zengo` (OpenCode Zen
-"go" subscription).
+"go" subscription), and the MiniMax direct endpoints `minimax`,
+`minimax-cn` (China), `minimax-anthropic`, `minimax-anthropic-cn` (China).
 
 - **claude-code** — `ANTHROPIC_BASE_URL` = `<proxy>/claude-code/anthropic`,
   `ANTHROPIC_API_KEY` = `sandboxd-proxy-injected`. Works for both an API key and
@@ -59,6 +60,26 @@ agent's stored credential for that upstream and injects it. Upstreams:
   the proxy's resolved **IP**, and the task's model is rewritten to `proxy/<id>`.)
 - **codex** — parked: its ChatGPT-subscription backend is a WebSocket that can't be
   proxied yet, so codex is hidden from the run picker.
+
+- **MiniMax** — a credential-only provider: connect a MiniMax API key in
+  Settings → AI Agents (`POST /v1/agents/minimax/api-key`). MiniMax is not a
+  task agent (no CLI, not in the run picker); its key is injected by the proxy
+  for the MiniMax direct upstreams. The OpenCode opencode model dropdown exposes
+  `MiniMax-M3` and `MiniMax-M2.7`; selecting one routes the task to the MiniMax
+  OpenAI-compatible endpoint with the connected key (the China region is
+  selected with `SANDBOXD_MINIMAX_REGION=cn_zh`, default `global_en`).
+
+  | Region | OpenAI-compatible | Anthropic-compatible |
+  |--------|-------------------|----------------------|
+  | `global_en` *(default)* | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+  | `cn_zh` | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
+  MiniMax model metadata (retained for operator reference): **MiniMax-M3** —
+  1,000,000-token context, image and video input, adaptive or disabled thinking,
+  pricing $0.60 / $2.40 / $0.12 per million input / output / cache-read tokens.
+  **MiniMax-M2.7** — 204,800-token context, text input, always-on thinking,
+  pricing $0.30 / $1.20 / $0.06 per million input / output / cache-read tokens.
+  MiniMax endpoints authorize with `Authorization: Bearer <key>`.
 
 **The real credential never appears in the sandbox filesystem or env** — verify
 with `mount | grep agent-auth` (none) and `ls /run/agent-auth` (absent).
@@ -201,6 +222,7 @@ Operator knobs for agent auth & task defaults (all optional; sensible defaults s
 | `SANDBOXD_DEFAULT_AGENT` | `opencode` | Agent used for tasks that don't specify one. |
 | `SANDBOXD_OPENCODE_ZEN_PATH` | `zen` | OpenCode Zen endpoint for opencode: `zen` (pay-as-you-go, full catalog) or `zengo` (the "go" subscription's models). See [OpenCode Zen: subscription vs pay-as-you-go](#opencode-zen-subscription-vs-pay-as-you-go). |
 | `SANDBOXD_OPENCODE_MODEL` | *(unset)* | Global default `--model` for opencode tasks that don't pass one. |
+| `SANDBOXD_MINIMAX_REGION` | `global_en` | MiniMax direct endpoint region for MiniMax models: `global_en` (`api.minimax.io`) or `cn_zh` (`api.minimaxi.com`). Requires a connected MiniMax API key. |
 
 Per-task, `POST /tasks` also accepts `agent`, `model`, and `continue` (tri-state —
 see [Running a task](#running-a-task)).


### PR DESCRIPTION
Reason: Add direct MiniMax API-key credentials and proxy upstreams for global and China OpenAI- and Anthropic-compatible endpoints, exposing MiniMax-M3 and MiniMax-M2.7.

## What changes

- **MiniMax as a credential-only provider** (`agentauth/registry.go`): a new `minimax` provider entry with no CLI binary and `Runnable=false`. The owner connects a MiniMax API key via the existing `POST /v1/agents/minimax/api-key` flow; it is stored opaquely like every other provider's key and is never mounted or env-injected into a sandbox.
- **Four MiniMax direct upstreams** (`authproxy/proxy.go`): `minimax` and `minimax-cn` (OpenAI-compatible, `/v1`), `minimax-anthropic` and `minimax-anthropic-cn` (Anthropic-compatible, `/anthropic`), for the global (`api.minimax.io`) and China (`api.minimaxi.com`) endpoints. `credFor` injects the connected MiniMax API key as `Authorization: Bearer` regardless of which coding agent carries the request (MiniMax uses Bearer for both API flavors). The opencode keyless-free-tier rewrite is skipped for MiniMax upstreams so a missing MiniMax key yields a clear 401 instead of a Zen fallback.
- **opencode routes MiniMax directly** (`cmd/runtimed/opencode.go`): `MiniMax-M3` and `MiniMax-M2.7` now route to the MiniMax OpenAI-compatible upstream (China selected with `SANDBOXD_MINIMAX_REGION=cn_zh`); all other models keep the existing `zen`/`zengo` path.
- **Console**: the opencode model dropdown exposes `MiniMax M3` and `MiniMax M2.7`; Settings hides non-runnable providers from the default-model picker and labels MiniMax as a model gateway.
- **Docs/env**: `docs/agent-auth.md` and `.env.example` document the MiniMax upstreams, region toggle, Bearer auth, and the retained MiniMax-M3 / MiniMax-M2.7 metadata (context window, pricing, input modality, cache, and thinking).

## Checks run

- `go test ./...` (control-plane) — all packages pass.
- `go vet ./...` and `gofmt -l .` — clean.
- `tsc --noEmit` and `vite build` (console) — pass.
- New unit tests: MiniMax credential injection (global + China + Anthropic-compatible + no-credential 401), `isMiniMaxUpstream`, and opencode proxy-config routing for MiniMax global/China plus a non-MiniMax regression guard.
