### PR TITLE
console: update-available notification (+ checker false-positive fix)

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -16,6 +16,10 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [apps, setApps] = useState<TApp[]>([])
   const [auth, setAuth] = useState<{ enabled: boolean; authenticated: boolean; password_set: boolean } | null>(null)
+  // Update notification: the control plane checks GitHub releases (cached ~6h)
+  // and reports update_available in /v1/settings. Dismissal is remembered per
+  // version, so each new release notifies exactly once.
+  const [upd, setUpd] = useState<{ latest: string; url?: string } | null>(null)
 
   const toast = useCallback((msg: string) => {
     const id = Date.now() + Math.floor(performance.now())
@@ -39,6 +43,14 @@ export default function App() {
   useEffect(() => {
     if (auth && (auth.authenticated || auth.enabled === false)) loadApps()
   }, [auth, loadApps])
+  useEffect(() => {
+    if (!(auth && (auth.authenticated || auth.enabled === false))) return
+    api.getSettings().then((s) => {
+      if (s.update_available && s.latest_version && localStorage.getItem('sandboxd-update-dismissed') !== s.latest_version) {
+        setUpd({ latest: s.latest_version, url: s.changelog_url })
+      }
+    }).catch(() => {})
+  }, [auth])
 
   const onAuthed = useCallback(() => { refreshAuth().then(loadApps) }, [refreshAuth, loadApps])
   const logout = useCallback(() => { api.logout().finally(() => setAuth((a) => (a ? { ...a, authenticated: false } : a))) }, [])
@@ -75,6 +87,23 @@ export default function App() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', background: c.bg, color: c.fg, fontFamily: font.sans, overflow: 'hidden' }}>
+      {/* UPDATE NOTIFICATION — one slim, dismissible strip per new release. */}
+      {upd && (
+        <div data-testid="update-banner" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10, flexShrink: 0, padding: '6px 40px 6px 16px', fontSize: 12.5, background: c.panel2, borderBottom: `1px solid ${c.border}`, position: 'relative' }}>
+          <span style={{ width: 7, height: 7, borderRadius: '50%', background: c.good, flexShrink: 0 }} />
+          <span>
+            <b>Update available: {upd.latest}</b> — run <span style={{ ...mono, fontSize: 11.5, background: c.bg, border: `1px solid ${c.border}`, borderRadius: 4, padding: '1px 6px' }}>./upgrade.sh</span> on your server.
+          </span>
+          {upd.url && <a href={upd.url} target="_blank" rel="noreferrer" style={{ color: c.link, textDecoration: 'none' }}>Release notes ↗</a>}
+          <span
+            data-testid="update-dismiss"
+            className="dc-hoverink"
+            onClick={() => { localStorage.setItem('sandboxd-update-dismissed', upd.latest); setUpd(null) }}
+            style={{ position: 'absolute', right: 14, color: c.muted, cursor: 'pointer', fontSize: 13 }}>
+            ✕
+          </span>
+        </div>
+      )}
       {/* TOP BAR */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 18, height: 52, flexShrink: 0, padding: '0 20px', borderBottom: `1px solid ${c.border}`, background: c.panel }}>
         <div onClick={() => setRoute({ name: 'apps' })} style={{ display: 'flex', alignItems: 'center', gap: 9, cursor: 'pointer' }}>

--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -27,6 +27,11 @@ export interface Preset {
 export interface Settings {
   version: string
   git_commit?: string
+  // Release-checker result (best-effort; cached server-side). update_available
+  // is false for main-tracking dev builds even when latest_version is set.
+  update_available: boolean
+  latest_version?: string
+  changelog_url?: string
   networking: {
     preview_domain: string
     public_http_port?: string

--- a/console/src/demo.ts
+++ b/console/src/demo.ts
@@ -37,7 +37,7 @@ const agents = [
 ]
 
 const settings = {
-  version: 'v0.3.0', git_commit: 'demo',
+  version: 'v0.3.0', git_commit: 'demo', update_available: false,
   networking: { preview_domain: 'localhost', public_http_port: '80', preview_base: 'http://*.preview.localhost', preview_tls: false, preview_entrypoint: 'web' },
   auth: { enabled: false },
   runtime: { storage_mode: 'directory', base_image: 'sandboxd-base:0.3.0' },

--- a/console/src/test/fixtures.ts
+++ b/console/src/test/fixtures.ts
@@ -70,6 +70,7 @@ export const configFixture: ConfigItem[] = [
 export const settingsFixture: Settings = {
   version: 'v0.4.0',
   git_commit: 'abc1234',
+  update_available: false,
   networking: {
     preview_domain: 'localhost',
     public_http_port: '18080',

--- a/control-plane/internal/telemetry/update.go
+++ b/control-plane/internal/telemetry/update.go
@@ -120,6 +120,12 @@ func (c *Checker) Latest(ctx context.Context) (version, url string, err error) {
 // whether the latest release is newer than current. It is best-effort: with no
 // cached result yet it returns (false, "", ""). When a result is cached it always
 // returns the latest version + changelog URL so callers can surface them.
+//
+// A current version that is not semver-like — a bare commit hash ("e2ca6f6") or
+// "dev", i.e. a build tracking main — would parse as 0.0.0 and make EVERY
+// release look newer, so those never report an update (the latest release info
+// is still returned for display). Tag-anchored describe forms ("v0.3.0-54-g…")
+// compare by their tag, so a build ahead of the latest release reports false.
 func (c *Checker) UpdateAvailable(current string) (available bool, latest, changelogURL string) {
 	c.mu.Lock()
 	have, tag, url := c.haveData, c.tag, c.url
@@ -127,7 +133,25 @@ func (c *Checker) UpdateAvailable(current string) (available bool, latest, chang
 	if !have || tag == "" {
 		return false, "", ""
 	}
+	if !semverLike(current) {
+		return false, tag, url
+	}
 	return CompareSemver(tag, current) > 0, tag, url
+}
+
+// semverLike reports whether v starts with a numeric (optionally "v"-prefixed)
+// version component — "v0.3.0", "0.4.1", "v0.3.0-54-g83f2f7" — as opposed to a
+// bare commit hash or "dev", which carry no comparable version at all.
+func semverLike(v string) bool {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	first := strings.SplitN(v, ".", 2)[0]
+	_, err := strconv.Atoi(strings.TrimSpace(first))
+	return err == nil
 }
 
 func (c *Checker) githubFetch(ctx context.Context) (tag, url string, err error) {

--- a/control-plane/internal/telemetry/update_test.go
+++ b/control-plane/internal/telemetry/update_test.go
@@ -80,3 +80,36 @@ func TestCheckerUpdateAvailableEmptyCacheIsSafe(t *testing.T) {
 		t.Error("empty/failed cache must yield update_available=false")
 	}
 }
+
+func TestCheckerUpdateAvailableNonSemverCurrent(t *testing.T) {
+	c := &Checker{
+		Fetch: func(context.Context) (string, string, error) {
+			return "v0.3.0", "https://github.com/tastyeffectco/sandboxd/releases/tag/v0.3.0", nil
+		},
+	}
+	if _, _, err := c.Latest(context.Background()); err != nil {
+		t.Fatalf("Latest: %v", err)
+	}
+
+	// A bare commit hash or "dev" (a build tracking main) parses as 0.0.0 and
+	// must NOT make the latest release look like an update — but the latest
+	// release info is still surfaced for display.
+	for _, cur := range []string{"e2ca6f6", "dev", "unknown"} {
+		avail, latest, url := c.UpdateAvailable(cur)
+		if avail {
+			t.Errorf("current=%q: no update should be reported for a non-semver build", cur)
+		}
+		if latest != "v0.3.0" || url == "" {
+			t.Errorf("current=%q: latest info should still be surfaced, got %q %q", cur, latest, url)
+		}
+	}
+
+	// Tag-anchored describe (ahead of the release) compares by its tag: no update.
+	if avail, _, _ := c.UpdateAvailable("v0.3.0-54-g83f2f7"); avail {
+		t.Error("v0.3.0-54-g… (ahead of v0.3.0) should not report an update")
+	}
+	// And a genuinely older tagged build still does.
+	if avail, _, _ := c.UpdateAvailable("v0.2.9"); !avail {
+		t.Error("v0.2.9 should report an update vs v0.3.0")
+	}
+}


### PR DESCRIPTION
Self-hosters had no way to learn an update exists — the backend checker existed and `/v1/settings` carried `update_available`, but the console never showed it.

**Console:** slim dismissible strip above the top bar when a newer release exists: *'● Update available: vX.Y.Z — run `./upgrade.sh` on your server · Release notes ↗ ✕'*. Dismissal is per-version (localStorage), so each release notifies exactly once. Demo build unaffected (`update_available:false` fixture).

**Checker bug fixed:** a current version that isn't semver-like (bare commit sha, `dev` — any main-tracking build) parsed as `0.0.0`, so **every release looked newer**: the live instance reported `update_available:true, latest=v0.3.0` while running commits *ahead of* v0.3.0. Naively shipping the banner would have shown a permanently-wrong notification to every main-tracker. Such builds now never claim an update (the latest-release info is still returned for display). Covered by a new unit test (sha/dev/unknown → false; `v0.3.0-54-g…` → false; `v0.2.9` → true).

Verified: `go test ./internal/telemetry` green in the project toolchain, gofmt/vet clean, console tsc clean + builds.