### PR TITLE
feat(brain): spoke notes (brain/*.md) + shared-concept radar

### DIFF
--- a/console/src/App.tsx
+++ b/console/src/App.tsx
@@ -4,7 +4,7 @@ import { c, font, mono, Card, Btn, StatusPill, Input, navItem } from './design/k
 import { PRESET_ICONS } from './design/presetIcons'
 import { STARTERS, STARTER_ICONS } from './design/starters'
 import { AppView } from './AppView'
-import { brainExcerpt, buildBrainGraph } from './brain'
+import { AppBrain, brainExcerpt, buildBrainGraph } from './brain'
 import { BrainGraph } from './BrainGraph'
 import { StoreView } from './StoreView'
 import { SettingsView } from './SettingsView'
@@ -432,20 +432,21 @@ function AppsScreen({ apps, reload, onOpen, onError, goStore }: { apps: TApp[]; 
 // Excerpt/graph logic lives in brain.ts (pure + unit-tested); this renders it.
 
 function BrainOverview({ apps, onOpen }: { apps: TApp[]; onOpen: (id: string) => void }) {
-  // null = no BRAIN.md (or no sandbox); undefined = still loading.
-  const [brains, setBrains] = useState<Record<string, string | null | undefined>>({})
+  // null = no sandbox; undefined = still loading; AppBrain = hub + spoke notes.
+  const [brains, setBrains] = useState<Record<string, AppBrain | null | undefined>>({})
 
   useEffect(() => {
     apps.forEach((a) => {
       if (!a.current_sandbox_id) { setBrains((b) => ({ ...b, [a.id]: null })); return }
-      api.getWorkspaceFile(a.current_sandbox_id, 'BRAIN.md')
-        .then((c) => setBrains((b) => ({ ...b, [a.id]: c })))
+      api.getAppBrain(a.current_sandbox_id)
+        .then((br) => setBrains((b) => ({ ...b, [a.id]: br })))
         .catch(() => setBrains((b) => ({ ...b, [a.id]: null })))
     })
   }, [apps])
 
-  const withBrain = apps.filter((a) => typeof brains[a.id] === 'string')
-  const without = apps.filter((a) => brains[a.id] === null)
+  const hasBrain = (id: string) => { const b = brains[id]; return !!b && (typeof b.hub === 'string' || Object.keys(b.spokes).length > 0) }
+  const withBrain = apps.filter((a) => hasBrain(a.id))
+  const without = apps.filter((a) => brains[a.id] !== undefined && !hasBrain(a.id))
 
   return (
     <div style={{ maxWidth: 920, margin: '0 auto', padding: '36px 40px 80px' }}>
@@ -462,27 +463,49 @@ function BrainOverview({ apps, onOpen }: { apps: TApp[]; onOpen: (id: string) =>
         const settled = apps.every((a) => brains[a.id] !== undefined)
         if (!settled || apps.length === 0) return null
         const g = buildBrainGraph(apps, brains)
-        if (g.edges.length === 0 && g.nodes.every((n) => n.ghost)) return null
+        if (g.edges.length === 0 && g.nodes.every((n) => n.empty)) return null
         return (
-          <Card style={{ padding: '8px 10px', marginBottom: 22 }}>
-            <BrainGraph nodes={g.nodes} edges={g.edges} onOpen={onOpen} />
-            <div style={{ ...mono, fontSize: 10.5, color: c.muted2, textAlign: 'center', paddingBottom: 6 }}>
-              Link projects from any brain with [[project-name]] — dashed nodes have no brain yet.
-            </div>
-          </Card>
+          <>
+            <Card style={{ padding: '8px 10px', marginBottom: 22 }}>
+              <BrainGraph nodes={g.nodes} edges={g.edges} onOpen={onOpen} />
+              <div style={{ ...mono, fontSize: 10.5, color: c.muted2, textAlign: 'center', paddingBottom: 6 }}>
+                Link projects &amp; concepts from any brain with [[name]] — dashed nodes have no note yet · err-* concepts flag repeat mistakes.
+              </div>
+            </Card>
+            {g.concepts.length > 0 && (
+              <Card style={{ padding: 16, marginBottom: 22 }} data-testid="brain-concepts">
+                <div style={{ fontFamily: font.display, fontWeight: 700, fontSize: 13, marginBottom: 4 }}>Concepts without a note yet</div>
+                <div style={{ color: c.muted2, fontSize: 12, marginBottom: 10 }}>
+                  Linked from your brains but written nowhere. A concept shared by several apps is knowledge worth a note — an <span style={{ ...mono, fontSize: 11 }}>err-*</span> concept shared by several apps is a <b style={{ color: c.fg2 }}>repeat mistake</b>.
+                </div>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  {g.concepts.slice(0, 12).map((cs) => (
+                    <span key={cs.slug} title={`${cs.mentions} mention${cs.mentions > 1 ? 's' : ''} across ${cs.apps} app${cs.apps > 1 ? 's' : ''}`}
+                      style={{ ...mono, fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 6, border: `1px dashed ${cs.isError ? c.warn : c.border2}`, borderRadius: 7, padding: '5px 11px', color: cs.isError ? c.warn : c.muted }}>
+                      <span style={{ width: 6, height: 6, borderRadius: '50%', background: cs.isError && cs.apps > 1 ? c.warn : c.muted2 }} />
+                      [[{cs.label}]]
+                      <span style={{ color: c.muted2, fontSize: 10.5 }}>{cs.apps}×</span>
+                    </span>
+                  ))}
+                </div>
+              </Card>
+            )}
+          </>
         )
       })()}
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(280px,1fr))', gap: 14 }} data-testid="brain-list">
         {withBrain.map((a) => {
-          const md = brains[a.id] as string
+          const b = brains[a.id] as AppBrain
+          const md = b.hub || ''
+          const spokeCount = Object.keys(b.spokes).length
           const excerpt = brainExcerpt(md)
           return (
             <Card key={a.id} style={{ padding: 16, cursor: 'pointer' }}>
               <div className="dc-hoverborder" onClick={() => onOpen(a.id)} data-testid="brain-card">
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
                   <span style={{ ...mono, fontWeight: 500, fontSize: 14, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{a.name}</span>
-                  <span style={{ ...mono, fontSize: 10, color: c.muted2 }}>{md.split('\n').length} lines</span>
+                  <span style={{ ...mono, fontSize: 10, color: c.muted2 }}>{md.split('\n').length} lines{spokeCount > 0 ? ` · ${spokeCount} note${spokeCount > 1 ? 's' : ''}` : ''}</span>
                 </div>
                 <div style={{ color: c.muted, fontSize: 12.5, lineHeight: 1.5, minHeight: 38 }}>
                   {excerpt || <i style={{ color: c.muted2 }}>No current state written yet.</i>}

--- a/console/src/AppView.tsx
+++ b/console/src/AppView.tsx
@@ -333,19 +333,24 @@ export function brainTemplate(appName: string): string {
     '## Dead ends',
     '<!-- What was tried and failed, and why — so nobody retries it. -->',
     '',
-    '<!-- Tip: link related projects with [[project-name]] — links appear in the Brain graph. -->',
+    '<!-- Tips: link projects & concepts with [[name]] — lowercase-slug concepts,',
+    '     err- prefix for error signatures, link before inventing a new name.',
+    '     When a topic outgrows ~30 lines, move it to brain/<topic>.md and link',
+    '     it from here — the agent reads this hub first and follows links. -->',
     '',
   ].join('\n')
 }
 
-// Keep BRAIN.md out of git the same way generated AGENTS.md is: a repo-local
-// `.git/info/exclude` entry (never committed, never pushed).
+// Keep the brain (hub + brain/ spoke notes) out of git the same way generated
+// AGENTS.md is: repo-local `.git/info/exclude` entries (never committed).
 async function ensureBrainExcluded(sandboxId: string): Promise<void> {
   try {
     const ex = (await api.getWorkspaceFile(sandboxId, '.git/info/exclude').catch(() => null)) || ''
-    if (!ex.split('\n').includes('BRAIN.md')) {
+    const lines = ex.split('\n')
+    const missing = ['BRAIN.md', 'brain/'].filter((l) => !lines.includes(l))
+    if (missing.length > 0) {
       const sep = ex === '' || ex.endsWith('\n') ? '' : '\n'
-      await api.putWorkspaceFile(sandboxId, 'workspace/app/.git/info/exclude', `${ex}${sep}BRAIN.md\n`)
+      await api.putWorkspaceFile(sandboxId, 'workspace/app/.git/info/exclude', `${ex}${sep}${missing.join('\n')}\n`)
     }
   } catch { /* advisory — a missing exclude never blocks saving the brain */ }
 }
@@ -353,19 +358,17 @@ async function ensureBrainExcluded(sandboxId: string): Promise<void> {
 // BrainView — lightweight read view of BRAIN.md: headings, lists, inline
 // code/bold, and clickable [[wikilinks]] (resolved against app names; dashed
 // when no such app exists yet). Deliberately not a full markdown renderer.
-function BrainView({ md, apps, onOpenApp }: { md: string; apps?: TApp[]; onOpenApp?: (id: string, tab?: string) => void }) {
-  const byName = new Map<string, string>()
-  for (const a of apps || []) byName.set(slugKey(a.name), a.id)
+function BrainView({ md, linkFor }: { md: string; linkFor: (target: string) => (() => void) | null }) {
   const inline = (line: string, key: number) => (
     <span key={key}>
       {splitInline(line).map((s, i) => {
         if (s.kind === 'code') return <code key={i} style={{ ...mono, fontSize: 12, background: c.panel2, border: `1px solid ${c.border}`, borderRadius: 4, padding: '0 5px' }}>{s.v}</code>
         if (s.kind === 'bold') return <b key={i}>{s.v}</b>
         if (s.kind === 'wiki') {
-          const id = byName.get(slugKey(s.v))
-          return id
-            ? <a key={i} onClick={() => onOpenApp?.(id, 'brain')} style={{ color: c.link, cursor: 'pointer', textDecoration: 'none' }} data-testid="brain-wikilink">[[{s.v}]]</a>
-            : <span key={i} title="No app with this name yet" style={{ color: c.muted2, borderBottom: `1px dashed ${c.muted2}` }}>[[{s.v}]]</span>
+          const go = linkFor(s.v)
+          return go
+            ? <a key={i} onClick={go} style={{ color: c.link, cursor: 'pointer', textDecoration: 'none' }} data-testid="brain-wikilink">[[{s.v}]]</a>
+            : <span key={i} title="No note or app with this name yet" style={{ color: c.muted2, borderBottom: `1px dashed ${c.muted2}` }}>[[{s.v}]]</span>
         }
         return <span key={i}>{s.v}</span>
       })}
@@ -387,34 +390,73 @@ function BrainView({ md, apps, onOpenApp }: { md: string; apps?: TApp[]; onOpenA
 }
 
 function BrainTab({ appName, sb, onError, toast, apps, onOpenApp }: { appName: string; sb: Sandbox | null; onError: (m: string) => void; toast: (m: string) => void; apps?: TApp[]; onOpenApp?: (id: string, tab?: string) => void }) {
-  const [text, setText] = useState<string | null>(null)
-  const [exists, setExists] = useState(false)
+  // docs: path -> content. 'BRAIN.md' is the hub; 'brain/<name>.md' are spoke
+  // notes (topics that outgrew the hub). The agent reads the hub first and
+  // follows its [[wikilinks]] into spokes only when a task needs them.
+  const [docs, setDocs] = useState<Record<string, string> | null>(null)
+  const [hubExists, setHubExists] = useState(false)
+  const [sel, setSel] = useState('BRAIN.md')
   const [dirty, setDirty] = useState(false)
   const [busy, setBusy] = useState(false)
   const [editing, setEditing] = useState(false)
 
   useEffect(() => {
     if (!sb) return
-    api.getWorkspaceFile(sb.id, 'BRAIN.md')
-      .then((c) => { setExists(c !== null); setText(c ?? '') })
+    api.getAppBrain(sb.id)
+      .then((b) => {
+        const d: Record<string, string> = {}
+        if (b.hub !== null) d['BRAIN.md'] = b.hub
+        for (const [name, content] of Object.entries(b.spokes)) d[`brain/${name}.md`] = content
+        setDocs(d); setHubExists(b.hub !== null); setSel('BRAIN.md')
+      })
       .catch((e) => onError((e as Error).message))
   }, [sb, onError])
 
-  const save = async (content: string) => {
+  const save = async (path: string, content: string) => {
     if (!sb) return
     setBusy(true)
     try {
-      await api.putWorkspaceFile(sb.id, 'workspace/app/BRAIN.md', content)
+      await api.putWorkspaceFile(sb.id, `workspace/app/${path}`, content)
       await ensureBrainExcluded(sb.id)
-      setText(content); setExists(true); setDirty(false)
+      setDocs((d) => ({ ...(d || {}), [path]: content }))
+      if (path === 'BRAIN.md') setHubExists(true)
+      setDirty(false)
       toast('Brain saved')
     } catch (e) { onError((e as Error).message) } finally { setBusy(false) }
   }
 
-  if (!sb) return <p style={{ color: c.muted2 }}>No sandbox yet — create one to give this app a brain.</p>
-  if (text === null) return <p style={{ color: c.muted2 }}>Loading…</p>
+  const switchDoc = (path: string) => {
+    if (dirty && !window.confirm('Discard unsaved changes?')) return
+    setSel(path); setDirty(false); setEditing(false)
+  }
 
-  if (!exists) {
+  const newNote = async () => {
+    const name = window.prompt('Note name (topic that outgrew the hub, e.g. "decisions" or "err-pg-connect-hang")')?.trim()
+    if (!name) return
+    const slug = slugKey(name)
+    if (!slug) return
+    const path = `brain/${slug}.md`
+    await save(path, `# ${name}\n\n`)
+    setSel(path); setEditing(true)
+  }
+
+  const spokePaths = Object.keys(docs || {}).filter((p) => p !== 'BRAIN.md').sort()
+  const text = docs?.[sel] ?? ''
+
+  // Wikilink resolution inside the viewer: own spoke notes first, then apps.
+  const linkFor = (target: string): (() => void) | null => {
+    const s = slugKey(target)
+    const spoke = spokePaths.find((p) => slugKey(p.replace(/^brain\//, '').replace(/\.md$/, '')) === s)
+    if (spoke) return () => switchDoc(spoke)
+    const app = (apps || []).find((a) => slugKey(a.name) === s)
+    if (app && onOpenApp) return () => onOpenApp(app.id, 'brain')
+    return null
+  }
+
+  if (!sb) return <p style={{ color: c.muted2 }}>No sandbox yet — create one to give this app a brain.</p>
+  if (docs === null) return <p style={{ color: c.muted2 }}>Loading…</p>
+
+  if (!hubExists && spokePaths.length === 0) {
     return (
       <Card style={{ padding: '26px 22px', textAlign: 'center' }} data-testid="brain-empty">
         <div style={{ fontFamily: font.display, fontWeight: 600, fontSize: 15, marginBottom: 6 }}>No brain yet</div>
@@ -422,29 +464,47 @@ function BrainTab({ appName, sb, onError, toast, apps, onOpenApp }: { appName: s
           <span style={{ ...mono, fontSize: 12 }}>BRAIN.md</span> is this project's memory — state, decisions, gotchas, dead ends.
           The agent reads it before every task and appends what it learns. It lives in the workspace, is kept out of git, and travels with snapshots and forks.
         </div>
-        <Btn variant="primary" disabled={busy} onClick={() => save(brainTemplate(appName))} data-testid="brain-create">Create BRAIN.md</Btn>
+        <Btn variant="primary" disabled={busy} onClick={() => save('BRAIN.md', brainTemplate(appName))} data-testid="brain-create">Create BRAIN.md</Btn>
       </Card>
     )
   }
 
   return (
     <div data-testid="brain-tab">
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
-        <span style={{ ...mono, fontSize: 11.5, color: c.muted }}>BRAIN.md ({text.split('\n').length} lines) — read by the agent before every task · git-excluded · link projects with [[name]]</span>
+      {/* doc switcher: the hub + spoke notes + new-note */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+        <span onClick={() => switchDoc('BRAIN.md')} className="dc-hoverborder" data-testid="brain-doc-hub"
+          style={{ ...mono, fontSize: 12, padding: '5px 11px', borderRadius: 7, cursor: 'pointer', border: `1px solid ${sel === 'BRAIN.md' ? c.faint : c.border}`, background: sel === 'BRAIN.md' ? c.panel2 : 'transparent', color: sel === 'BRAIN.md' ? c.fg : c.muted }}>
+          BRAIN.md
+        </span>
+        {spokePaths.map((p) => {
+          const name = p.replace(/^brain\//, '').replace(/\.md$/, '')
+          const active = sel === p
+          return (
+            <span key={p} onClick={() => switchDoc(p)} className="dc-hoverborder" data-testid={`brain-doc-${name}`}
+              style={{ ...mono, fontSize: 12, padding: '5px 11px', borderRadius: 7, cursor: 'pointer', border: `1px solid ${active ? c.faint : c.border}`, background: active ? c.panel2 : 'transparent', color: active ? c.fg : c.muted }}>
+              {name}
+            </span>
+          )
+        })}
+        <span onClick={newNote} className="dc-hoverink" data-testid="brain-new-note" style={{ ...mono, fontSize: 12, padding: '5px 9px', color: c.muted2, cursor: 'pointer' }}>+ note</span>
         <div style={{ flex: 1 }} />
-        {editing && dirty && <Btn variant="primary" disabled={busy} onClick={() => { save(text); setEditing(false) }} data-testid="brain-save">{busy ? 'Saving…' : 'Save'}</Btn>}
+        {editing && dirty && <Btn variant="primary" disabled={busy} onClick={() => { save(sel, text); setEditing(false) }} data-testid="brain-save">{busy ? 'Saving…' : 'Save'}</Btn>}
         <Btn onClick={() => setEditing((e) => !e)} data-testid="brain-edit-toggle">{editing ? 'View' : 'Edit'}</Btn>
+      </div>
+      <div style={{ ...mono, fontSize: 11, color: c.muted2, marginBottom: 8 }}>
+        {sel} ({text.split('\n').length} lines) — read by the agent · git-excluded · [[name]] links notes, apps &amp; concepts
       </div>
       {editing ? (
         <textarea
           value={text}
-          onChange={(e) => { setText(e.target.value); setDirty(true) }}
+          onChange={(e) => { setDocs((d) => ({ ...(d || {}), [sel]: e.target.value })); setDirty(true) }}
           spellCheck={false}
           data-testid="brain-editor"
           style={{ width: '100%', height: 520, resize: 'vertical', background: c.panel, color: c.fg, border: `1px solid ${c.border}`, borderRadius: 9, padding: '14px 16px', ...mono, fontSize: 12.5, lineHeight: 1.55 }}
         />
       ) : (
-        <BrainView md={text} apps={apps} onOpenApp={onOpenApp} />
+        <BrainView md={text} linkFor={linkFor} />
       )}
     </div>
   )

--- a/console/src/BrainGraph.tsx
+++ b/console/src/BrainGraph.tsx
@@ -77,22 +77,24 @@ export function BrainGraph({ nodes, edges, onOpen }: { nodes: BrainNode[]; edges
       })}
       {nodes.map((node) => {
         const p = pos.get(node.id)!
-        const r = node.ghost ? 6 : Math.min(13, 8 + node.lines / 40)
-        const clickable = !node.id.startsWith('ghost:')
+        const isErr = node.kind === 'concept' && node.id.startsWith('ghost:err-')
+        const r = node.kind === 'concept' ? 6 : node.kind === 'spoke' ? 6.5 : node.empty ? 7 : Math.min(13, 8 + node.lines / 40)
+        const clickable = node.kind !== 'concept' && !!node.appId
+        const stroke = isErr ? c.warn : node.empty ? c.muted2 : node.kind === 'spoke' ? c.muted : c.ink
         return (
           <g key={node.id}
             onMouseEnter={() => setHover(node.id)} onMouseLeave={() => setHover(null)}
-            onClick={() => clickable && onOpen(node.id)}
+            onClick={() => clickable && onOpen(node.appId!)}
             style={{ cursor: clickable ? 'pointer' : 'default' }}
             opacity={active(node.id) ? 1 : 0.3}>
             <circle cx={p.x} cy={p.y} r={r}
-              fill={node.ghost ? 'transparent' : c.ink}
-              stroke={node.ghost ? c.muted2 : c.ink}
-              strokeWidth={node.ghost ? 1.2 : 0}
-              strokeDasharray={node.ghost ? '3 3' : undefined}
+              fill={node.empty ? 'transparent' : node.kind === 'spoke' ? c.muted : c.ink}
+              stroke={stroke}
+              strokeWidth={node.empty ? 1.2 : node.kind === 'spoke' ? 0 : 0}
+              strokeDasharray={node.empty ? '3 3' : undefined}
               style={{ transition: 'opacity .15s ease' }} />
             <text x={p.x} y={p.y + r + 13} textAnchor="middle"
-              style={{ fontFamily: font.mono, fontSize: 10.5, fill: node.ghost ? c.muted2 : c.fg, userSelect: 'none' }}>
+              style={{ fontFamily: font.mono, fontSize: node.kind === 'app' ? 10.5 : 9.5, fill: node.empty ? (isErr ? c.warn : c.muted2) : node.kind === 'spoke' ? c.muted : c.fg, userSelect: 'none' }}>
               {node.label.length > 22 ? node.label.slice(0, 21) + '…' : node.label}
             </text>
           </g>

--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -391,6 +391,24 @@ export const api = {
     }
     return res.text()
   },
+  // Load an app's whole brain: the BRAIN.md hub plus any spoke notes under
+  // brain/ (topics that outgrew the hub). Missing dir/file = empty brain.
+  getAppBrain: async (sandboxId: string): Promise<{ hub: string | null; spokes: Record<string, string> }> => {
+    const hub = await api.getWorkspaceFile(sandboxId, 'BRAIN.md').catch(() => null)
+    const spokes: Record<string, string> = {}
+    try {
+      const l = await api.listFiles(sandboxId, { path: 'brain' })
+      const mds = (l.entries || []).filter((e) => e.type === 'file' && e.path.endsWith('.md'))
+      const contents = await Promise.all(mds.map((e) => api.getWorkspaceFile(sandboxId, e.path.startsWith('brain/') ? e.path : `brain/${e.path}`).catch(() => null)))
+      mds.forEach((e, i) => {
+        const c = contents[i]
+        if (typeof c !== 'string') return
+        const name = e.path.replace(/^brain\//, '').replace(/\.md$/, '')
+        spokes[name] = c
+      })
+    } catch { /* no brain/ directory yet */ }
+    return { hub, spokes }
+  },
   putWorkspaceFile: async (sandboxId: string, path: string, content: string): Promise<void> => {
     const res = await fetch(`/v1/sandboxes/${sandboxId}/files?path=${encodeURIComponent(path)}`, {
       method: 'PUT',

--- a/console/src/brain.test.ts
+++ b/console/src/brain.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { parseWikiLinks, slugKey, buildBrainGraph, brainExcerpt, splitInline } from './brain'
+import { parseWikiLinks, slugKey, buildBrainGraph, brainExcerpt, splitInline, AppBrain } from './brain'
+
+const hb = (hub: string | null, spokes: Record<string, string> = {}): AppBrain => ({ hub, spokes })
 
 describe('parseWikiLinks', () => {
   it('finds links, trims, keeps order', () => {
@@ -27,32 +29,69 @@ describe('buildBrainGraph', () => {
     { id: 'a3', name: 'no-brain-yet' },
   ]
 
-  it('links brains to apps by name and creates ghosts for unresolved targets', () => {
+  it('links brains to apps by name and creates concept ghosts for unresolved targets', () => {
     const { nodes, edges } = buildBrainGraph(apps, {
-      a1: 'talks to [[Todo App]] and shares [[Auth Brick]]',
-      a2: 'fronted by [[API Gateway]]',
+      a1: hb('talks to [[Todo App]] and shares [[Auth Brick]]'),
+      a2: hb('fronted by [[API Gateway]]'),
       a3: null,
     })
     expect(edges).toContainEqual({ from: 'a1', to: 'a2' })
     expect(edges).toContainEqual({ from: 'a2', to: 'a1' })
     expect(edges).toContainEqual({ from: 'a1', to: 'ghost:auth-brick' })
     const ghost = nodes.find((n) => n.id === 'ghost:auth-brick')
-    expect(ghost?.ghost).toBe(true)
+    expect(ghost?.kind).toBe('concept')
+    expect(ghost?.empty).toBe(true)
     expect(ghost?.label).toBe('Auth Brick')
   })
 
-  it('marks apps without brains as ghost nodes but never invents edges from them', () => {
-    const { nodes, edges } = buildBrainGraph(apps, { a1: 'x', a2: 'y', a3: null })
-    expect(nodes.find((n) => n.id === 'a3')?.ghost).toBe(true)
+  it('marks apps without brains as empty but never invents edges from them', () => {
+    const { nodes, edges } = buildBrainGraph(apps, { a1: hb('x'), a2: hb('y'), a3: null })
+    expect(nodes.find((n) => n.id === 'a3')?.empty).toBe(true)
     expect(edges).toEqual([])
   })
 
   it('drops self-links and duplicate edges', () => {
     const { edges } = buildBrainGraph(apps, {
-      a1: '[[api-gateway]] then [[Todo App]] and again [[todo app]]',
+      a1: hb('[[api-gateway]] then [[Todo App]] and again [[todo app]]'),
       a2: null, a3: null,
     })
     expect(edges).toEqual([{ from: 'a1', to: 'a2' }])
+  })
+
+  it('adds spoke nodes with an implicit hub→spoke edge', () => {
+    const { nodes, edges } = buildBrainGraph(apps, {
+      a1: hb('details in [[decisions]]', { decisions: '- D1: chose postgres' }),
+      a2: null, a3: null,
+    })
+    const spoke = nodes.find((n) => n.kind === 'spoke')
+    expect(spoke?.id).toBe('a1:decisions')
+    expect(spoke?.appId).toBe('a1')
+    // one implicit ownership edge; the [[decisions]] wikilink dedupes into it
+    expect(edges.filter((e) => e.from === 'a1' && e.to === 'a1:decisions')).toHaveLength(1)
+  })
+
+  it('resolves own spokes before app names and lets spokes link outward', () => {
+    const { edges } = buildBrainGraph(apps, {
+      a1: hb('see [[notes]]', { notes: 'depends on [[Todo App]] and hits [[err-pg-hang]]' }),
+      a2: null, a3: null,
+    })
+    expect(edges).toContainEqual({ from: 'a1:notes', to: 'a2' })
+    expect(edges).toContainEqual({ from: 'a1:notes', to: 'ghost:err-pg-hang' })
+  })
+
+  it('unifies the same concept across apps and ranks shared/error concepts', () => {
+    const { nodes, concepts } = buildBrainGraph(apps, {
+      a1: hb('hit [[err-pg-hang]] again, uses [[postgres]]'),
+      a2: hb('also hit [[err-pg-hang]]'),
+      a3: null,
+    })
+    // one shared node, not two
+    expect(nodes.filter((n) => n.id === 'ghost:err-pg-hang')).toHaveLength(1)
+    const err = concepts.find((c) => c.slug === 'err-pg-hang')
+    expect(err).toMatchObject({ apps: 2, mentions: 2, isError: true })
+    // shared (2 apps) ranks above single-app postgres
+    expect(concepts[0].slug).toBe('err-pg-hang')
+    expect(concepts.find((c) => c.slug === 'postgres')?.isError).toBe(false)
   })
 })
 

--- a/console/src/brain.ts
+++ b/console/src/brain.ts
@@ -1,15 +1,37 @@
 // Project Brain — pure logic (no React, no fetch) so it is unit-testable:
-// wikilink parsing, cross-brain graph building, the "Current state" excerpt,
-// and the inline splitter the Brain tab's view mode renders from.
+// wikilink parsing, the cross-brain knowledge graph (hub + spoke notes +
+// concept ghosts), shared-concept stats, the "Current state" excerpt, and the
+// inline splitter the Brain tab's view mode renders from.
+
+// An app's brain: the hub (BRAIN.md) plus optional spoke notes under brain/
+// ("decisions" -> content of brain/decisions.md). Spokes hold topics that
+// outgrew the hub; the hub links to them.
+export interface AppBrain {
+  hub: string | null
+  spokes: Record<string, string>
+}
 
 export interface BrainNode {
-  id: string      // app id, or "ghost:<slug>" for an unresolved link target
+  id: string        // app id | "<appId>:<spoke-slug>" | "ghost:<slug>"
   label: string
-  ghost: boolean  // true = mentioned in a brain but has no brain of its own
-  lines: number   // brain size (0 for ghosts)
+  kind: 'app' | 'spoke' | 'concept'
+  lines: number
+  appId?: string    // spokes: the owning app (click target)
+  empty: boolean    // dashed in the graph: app without a brain, or a concept
 }
 
 export interface BrainEdge { from: string; to: string }
+
+// A concept: a [[wikilink]] target that resolves to no app and no spoke.
+// Mentioned across >1 app it is shared knowledge — an err-* concept with
+// multiple apps is the repeat-mistake signal.
+export interface ConceptStat {
+  slug: string
+  label: string
+  mentions: number  // total inbound links
+  apps: number      // distinct apps linking it
+  isError: boolean  // err-* naming convention
+}
 
 // slugKey normalizes a name for matching: "[[API Gateway]]" links the app
 // named "api-gateway" (case/space/punctuation-insensitive).
@@ -30,55 +52,79 @@ export function parseWikiLinks(md: string): string[] {
   return out
 }
 
-// buildBrainGraph turns apps + their brain contents into nodes and edges.
-// Every app is a node (ghost when it has no brain yet); wikilinks that match
-// an app name (by slugKey) become edges; unmatched links become ghost concept
-// nodes. Self-links and duplicate edges are dropped.
+// buildBrainGraph turns apps + their brains into the knowledge graph.
+// Nodes: every app (dashed when brainless), every spoke note, every unresolved
+// concept. Edges: hub→spoke (details live there), plus each [[wikilink]] —
+// resolved own-spokes first, then app names, else a concept ghost. Ghost slugs
+// are GLOBAL, so two apps linking [[err-x]] converge on one shared node —
+// cross-project backlinks with no central vault. Self-links and duplicate
+// edges are dropped.
 export function buildBrainGraph(
   apps: { id: string; name: string }[],
-  brains: Record<string, string | null | undefined>,
-): { nodes: BrainNode[]; edges: BrainEdge[] } {
-  const bySlug = new Map<string, string>() // slug -> app id
-  for (const a of apps) bySlug.set(slugKey(a.name), a.id)
+  brains: Record<string, AppBrain | null | undefined>,
+): { nodes: BrainNode[]; edges: BrainEdge[]; concepts: ConceptStat[] } {
+  const appBySlug = new Map<string, string>()
+  for (const a of apps) appBySlug.set(slugKey(a.name), a.id)
 
-  const nodes: BrainNode[] = apps.map((a) => {
-    const md = brains[a.id]
-    return {
-      id: a.id,
-      label: a.name,
-      ghost: typeof md !== 'string',
-      lines: typeof md === 'string' ? md.split('\n').length : 0,
-    }
-  })
-
+  const nodes: BrainNode[] = []
   const edges: BrainEdge[] = []
   const seen = new Set<string>()
-  const ghosts = new Map<string, string>() // slug -> label as first written
+  const concepts = new Map<string, { label: string; mentions: number; apps: Set<string> }>()
+
+  const addEdge = (from: string, to: string) => {
+    const key = `${from}->${to}`
+    if (from === to || seen.has(key)) return
+    seen.add(key)
+    edges.push({ from, to })
+  }
 
   for (const a of apps) {
-    const md = brains[a.id]
-    if (typeof md !== 'string') continue
-    for (const target of parseWikiLinks(md)) {
-      const slug = slugKey(target)
-      if (!slug) continue
-      let to = bySlug.get(slug)
-      if (to === a.id) continue // self-link
-      if (!to) {
-        to = `ghost:${slug}`
-        if (!ghosts.has(slug)) ghosts.set(slug, target)
+    const b = brains[a.id]
+    const hub = b && typeof b.hub === 'string' ? b.hub : null
+    const spokes = (b && b.spokes) || {}
+    const spokeNames = Object.keys(spokes)
+
+    nodes.push({
+      id: a.id, label: a.name, kind: 'app', appId: a.id,
+      lines: hub ? hub.split('\n').length : 0,
+      empty: hub === null && spokeNames.length === 0,
+    })
+
+    const spokeIdBySlug = new Map<string, string>()
+    for (const name of spokeNames) {
+      const sid = `${a.id}:${slugKey(name)}`
+      spokeIdBySlug.set(slugKey(name), sid)
+      nodes.push({ id: sid, label: name, kind: 'spoke', appId: a.id, lines: spokes[name].split('\n').length, empty: false })
+      addEdge(a.id, sid) // the hub owns its spokes
+    }
+
+    const docs: { source: string; md: string }[] = []
+    if (hub) docs.push({ source: a.id, md: hub })
+    for (const name of spokeNames) docs.push({ source: spokeIdBySlug.get(slugKey(name))!, md: spokes[name] })
+
+    for (const doc of docs) {
+      for (const target of parseWikiLinks(doc.md)) {
+        const slug = slugKey(target)
+        if (!slug) continue
+        const to = spokeIdBySlug.get(slug) ?? appBySlug.get(slug)
+        if (to) { addEdge(doc.source, to); continue }
+        addEdge(doc.source, `ghost:${slug}`)
+        const cs = concepts.get(slug) || { label: target, mentions: 0, apps: new Set<string>() }
+        cs.mentions++; cs.apps.add(a.id)
+        concepts.set(slug, cs)
       }
-      const key = `${a.id}->${to}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      edges.push({ from: a.id, to })
     }
   }
 
-  for (const [slug, label] of ghosts) {
-    nodes.push({ id: `ghost:${slug}`, label, ghost: true, lines: 0 })
+  for (const [slug, cs] of concepts) {
+    nodes.push({ id: `ghost:${slug}`, label: cs.label, kind: 'concept', lines: 0, empty: true })
   }
 
-  return { nodes, edges }
+  const stats: ConceptStat[] = [...concepts.entries()]
+    .map(([slug, cs]) => ({ slug, label: cs.label, mentions: cs.mentions, apps: cs.apps.size, isError: slug.startsWith('err-') }))
+    .sort((x, y) => y.apps - x.apps || y.mentions - x.mentions || x.slug.localeCompare(y.slug))
+
+  return { nodes, edges, concepts: stats }
 }
 
 // brainExcerpt: the section under `## Current state` when present (lenient —

--- a/console/src/demo.ts
+++ b/console/src/demo.ts
@@ -65,7 +65,8 @@ const files = {
   ],
 }
 const fileContents: Record<string, string> = {
-  'BRAIN.md': `# Brain — Todo App\n\n## What this is\nPersonal todo list, single user, deployed as a sandboxd preview.\n\n## Current state\nAdd/remove works. Next: persistence — items reset on reload.\n\n## Stack & key choices\n- React + Vite, no backend — localStorage is enough for v1. (2026-07-09)\n- Reuses the shared [[Auth Brick]] pattern; images go through [[Image Resizer]].\n\n## Decisions\n- D1 (2026-07-09): No user accounts — single-user tool, auth is pure overhead.\n\n## Gotchas & environment facts\n- Vite dev server must bind **0.0.0.0** or the preview 404s.\n  Verify: \`grep -n "host" sandbox.yaml\`\n\n## Dead ends\n- Tried IndexedDB wrapper (idb) — overkill for a flat list, localStorage wins.\n`,
+  'BRAIN.md': `# Brain — Todo App\n\n## What this is\nPersonal todo list, single user, deployed as a sandboxd preview.\n\n## Current state\nAdd/remove works. Next: persistence — items reset on reload.\n\n## Stack & key choices\n- React + Vite, no backend — localStorage is enough for v1. (2026-07-09)\n- Reuses the shared [[Auth Brick]] pattern; images go through [[Image Resizer]].\n\n## Decisions\nFull log with reasoning: [[decisions]]\n\n## Gotchas & environment facts\n- Vite dev server must bind **0.0.0.0** or the preview 404s — see [[err-vite-host-binding]].\n  Verify: \`grep -n "host" sandbox.yaml\`\n\n## Dead ends\n- Tried IndexedDB wrapper (idb) — overkill for a flat list, localStorage wins.\n`,
+  'brain/decisions.md': `# decisions\n\n- D2 (2026-07-12): Ship without a service worker — offline mode can wait for real demand.\n- D1 (2026-07-09): No user accounts — single-user tool, auth is pure overhead.\n  Related: the shared [[Auth Brick]] exists if this ever changes.\n`,
   'src/App.tsx': `import { useState } from 'react'\n\nexport default function App() {\n  const [items, setItems] = useState<string[]>(['Try sandboxd'])\n  const [text, setText] = useState('')\n  return (\n    <main>\n      <h1>Todo</h1>\n      <input value={text} onChange={e => setText(e.target.value)} />\n      <button onClick={() => { setItems([...items, text]); setText('') }}>Add</button>\n      <ul>{items.map((t, i) => <li key={i} onClick={() => setItems(items.filter((_, j) => j !== i))}>{t}</li>)}</ul>\n    </main>\n  )\n}\n`,
   'sandbox.yaml': `version: 1\nweb:\n  command: "[ -x node_modules/.bin/vite ] || pnpm install; pnpm exec vite --host 0.0.0.0 --port 3000"\n  port: 3000\n  health_path: "/"\n`,
   'package.json': `{\n  "name": "todo-app",\n  "private": true,\n  "scripts": { "dev": "vite", "build": "vite build" }\n}\n`,
@@ -126,7 +127,13 @@ function route(method: string, url: string): { status: number; body?: unknown; t
   if (match(u, /\/v1\/apps\/[^/]+\/snapshots$/)) return { status: 200, body: { snapshots: [{ id: 'snap1', name: 'before-deploy', created_at: '2026-07-09T10:05:00Z' }] } }
   if (match(u, /\/v1\/sandboxes\/[^/]+\/tasks\/[^/]+$/)) return { status: 200, body: tasks[0] }
   if (match(u, /\/v1\/sandboxes\/[^/]+\/tasks$/)) return { status: 200, body: { tasks } }
-  if (match(u, /\/v1\/sandboxes\/[^/]+\/files$/)) return { status: 200, body: files }
+  if (match(u, /\/v1\/sandboxes\/[^/]+\/files$/)) {
+    const p = decodeURIComponent((q.match(/path=([^&]*)/)?.[1] || ''))
+    if (p === 'brain') return { status: 200, body: { path: 'brain', recursive: false, entries: [
+      { name: 'decisions.md', path: 'brain/decisions.md', type: 'file', dir: false, size: 380 },
+    ] } }
+    return { status: 200, body: files }
+  }
   if (match(u, /\/v1\/sandboxes\/[^/]+\/processes\/[^/]+\/logs$/)) return { status: 200, body: { process: 'web', lines: ['VITE ready in 312 ms', '➜  Local:   http://localhost:3000/'] } }
   if (match(u, /\/v1\/sandboxes\/[^/]+$/)) return { status: 200, body: sandbox }
   if (match(u, /\/v1\/apps\/[^/]+$/)) return { status: 200, body: app }


### PR DESCRIPTION
Continues #93 — the multi-doc vault layer:

- **Hub & spokes:** `BRAIN.md` stays the hub the agent always reads first; topics that outgrow ~30 lines move to `brain/<topic>.md`, linked from the hub. Brain tab gets a **doc switcher** and **+ note**; wikilinks resolve own spokes → apps → concept ghosts.
- **Shared-concept radar:** ghost slugs are global, so `[[err-pg-hang]]` linked from two apps converges on **one shared node** — cross-project backlinks with no central vault. A new panel ranks unwritten concepts by app-spread; **`err-*` concepts shared by several apps are flagged as repeat mistakes** — the §9 metric falling out of link structure.
- Graph renders spokes (smaller solid nodes, implicit hub→spoke edge) and warns on error concepts.
- `brain/` joins the git exclude; template teaches naming (lowercase-slug, `err-` prefix, link-before-inventing) + the spoke rule.
- **Core untouched**; `api.getAppBrain` shared by tab + overview; **14 unit tests** on the pure logic; demo fixtures include a spoke + error concept.

Verified: vitest 14/14, tsc clean, both bundles build, deployed live.