### PR TITLE
fix: self-healing start — recreate sandboxes whose container is stale or missing

### DIFF
--- a/control-plane/cmd/sandboxd/main.go
+++ b/control-plane/cmd/sandboxd/main.go
@@ -51,6 +51,7 @@ import (
 	nginxwatch "github.com/tastyeffectco/sandboxd/control-plane/internal/nginx"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/reaper"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/reconcile"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/sandboxspec"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/secrets"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/snapshot"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
@@ -462,6 +463,37 @@ func main() {
 				log.Warn("gvisor: could not resolve agent proxy host to IP; sandboxes may fail to reach it", "host", u.Hostname())
 			}
 		}
+	}
+
+	// Self-healing start: rebuild a container that is missing, or that was
+	// created from an older base image than we now run. The base image carries
+	// runtimed (the in-sandbox supervisor), so without this an upgrade never
+	// reaches long-lived sandboxes and they keep the old supervisor — and miss
+	// new agent/model support. Lossless: everything durable is in the workspace
+	// bind mount, and the container rootfs is read-only by construction.
+	wakeHandler.Image = image
+	wakeHandler.Recreate = func(ctx context.Context, sb *store.Sandbox) error {
+		spec := sandboxspec.Build(sb, sandboxspec.Env{
+			Image:             image,
+			Network:           network,
+			Userns:            userns,
+			Runtime:           sbxRuntime,
+			DNSResolvConf:     dnsResolvConf,
+			PreviewDomain:     domain,
+			PreviewEntrypoint: previewEntrypoint,
+			PreviewTLS:        previewTLS,
+			AgentProxyURL:     agentProxyURL,
+			OpencodeModel:     envDefault("SANDBOXD_OPENCODE_MODEL", ""),
+			OpencodeZenPath:   envDefault("SANDBOXD_OPENCODE_ZEN_PATH", ""),
+			RuntimePreset:     runtimePresetForSandbox(ctx, st, sb),
+		})
+		// Remove any existing container first so the name is free; ignore a
+		// not-found (the common case) and let Run surface a real failure.
+		if err := dockerClient.Remove(ctx, spec.Name); err != nil && err != docker.ErrNotFound {
+			log.Warn("recreate: remove existing container failed (continuing)", "err", err.Error())
+		}
+		_, err := dockerClient.Run(ctx, spec)
+		return err
 	}
 
 	server := &api.Server{
@@ -985,4 +1017,18 @@ func buildIdent() (version, gitCommit string) {
 		gitCommit = gitCommit[:12]
 	}
 	return version, gitCommit
+}
+
+// runtimePresetForSandbox returns the owning app's runtime preset, so a
+// recreated container gets the same RUNTIMED_RUNTIME_PRESET it was created
+// with. Best-effort: an unknown app just means runtimed uses its default.
+func runtimePresetForSandbox(ctx context.Context, st *store.Store, sb *store.Sandbox) string {
+	if sb == nil || !sb.AppID.Valid || sb.AppID.String == "" {
+		return ""
+	}
+	app, err := st.GetApp(ctx, sb.AppID.String)
+	if err != nil || app == nil || !app.RuntimePreset.Valid {
+		return ""
+	}
+	return app.RuntimePreset.String
 }

--- a/control-plane/internal/sandboxspec/spec.go
+++ b/control-plane/internal/sandboxspec/spec.go
@@ -1,0 +1,116 @@
+// Package sandboxspec builds the docker RunSpec for a sandbox from its stored
+// row, so a container can be (re)created from the database alone.
+//
+// Why this exists: the sandbox base image carries `runtimed` (the in-sandbox
+// supervisor). Upgrading sandboxd rebuilds that image, but a container created
+// from the OLD image keeps running the OLD runtimed until it is recreated —
+// so new agent/model support silently never reaches long-lived sandboxes
+// ("Model X is not supported" on an otherwise up-to-date install). Recreating
+// is safe because ALL durable state lives in the workspace bind mount, never
+// in the container's writable layer (the rootfs is read-only).
+package sandboxspec
+
+import (
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/docker"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/traefik"
+)
+
+// Env carries the instance-level settings a sandbox container needs. These
+// mirror the values the create path passes; keeping them in one struct lets
+// the recreate path produce an identical container.
+type Env struct {
+	Image             string // current base image (the whole point: may be newer)
+	Network           string
+	Userns            string
+	Runtime           string // "" = docker default, "runsc" = gVisor
+	DNSResolvConf     string // gVisor: host resolv.conf to bind-mount
+	PreviewDomain     string
+	PreviewEntrypoint string
+	PreviewTLS        bool
+	AgentProxyURL     string
+	OpencodeModel     string
+	OpencodeZenPath   string
+	RuntimePreset     string   // from the owning app, when known
+	AgentAuthMounts   []string // only when the auth proxy is disabled
+}
+
+// Build returns the RunSpec for `sb`. It reproduces the create path's flags:
+// read-only rootfs, all capabilities dropped, no-new-privileges, tmpfs /tmp,
+// the workspace bind mount, and the Traefik preview labels.
+func Build(sb *store.Sandbox, e Env) docker.RunSpec {
+	name := "s-" + sb.ID
+
+	env := []string{}
+	if e.RuntimePreset != "" {
+		env = append(env, "RUNTIMED_RUNTIME_PRESET="+e.RuntimePreset)
+	}
+	if e.AgentProxyURL != "" {
+		env = append(env, "RUNTIMED_ANTHROPIC_PROXY="+e.AgentProxyURL)
+	}
+	if e.OpencodeModel != "" {
+		env = append(env, "RUNTIMED_OPENCODE_MODEL="+e.OpencodeModel)
+	}
+	if e.OpencodeZenPath != "" {
+		env = append(env, "SANDBOXD_OPENCODE_ZEN_PATH="+e.OpencodeZenPath)
+	}
+
+	volumes := append([]string{sb.WorkspaceMnt + ":/home/sandbox"}, e.AgentAuthMounts...)
+	if e.DNSResolvConf != "" {
+		volumes = append(volumes, e.DNSResolvConf+":/etc/resolv.conf:ro")
+	}
+
+	// Preview routers: the stored ports, ensuring the resolved web port is
+	// present (mirrors ensurePort in the create path). A port-less sandbox
+	// stays preview-less.
+	ports := append([]int(nil), sb.Ports...)
+	if len(ports) > 0 {
+		web := 3000
+		if sb.WebPort.Valid && sb.WebPort.Int64 > 0 {
+			web = int(sb.WebPort.Int64)
+		}
+		found := false
+		for _, p := range ports {
+			if p == web {
+				found = true
+				break
+			}
+		}
+		if !found {
+			ports = append(ports, web)
+		}
+	}
+	visibility := sb.Visibility
+	if visibility == "" {
+		visibility = "private"
+	}
+	labels := traefik.Labels(sb.ID, ports, e.PreviewDomain, visibility, e.PreviewEntrypoint, e.PreviewTLS)
+
+	return docker.RunSpec{
+		Name:        name,
+		Hostname:    name,
+		Network:     e.Network,
+		Userns:      e.Userns,
+		Runtime:     e.Runtime,
+		ReadOnly:    true,
+		CapDrop:     []string{"ALL"},
+		SecurityOpt: []string{"no-new-privileges"},
+		CPUShares:   100,
+		Memory:      "10g",
+		MemorySwap:  "10g",
+		PidsLimit:   1024,
+		Ulimits:     []string{"nofile=65536:65536"},
+		Tmpfs:       []string{"/tmp:size=512m", "/var/tmp:size=128m"},
+		Env:         env,
+		Volumes:     volumes,
+		Labels:      labels,
+		Image:       e.Image,
+	}
+}
+
+// NeedsRecreate reports whether a container should be replaced before start:
+// it was built from a different image than the one the instance now runs.
+// After an upgrade this is what carries a new runtimed into old sandboxes.
+func NeedsRecreate(containerImage, currentImage string) bool {
+	return containerImage != "" && currentImage != "" && containerImage != currentImage
+}

--- a/control-plane/internal/sandboxspec/spec_test.go
+++ b/control-plane/internal/sandboxspec/spec_test.go
@@ -1,0 +1,123 @@
+package sandboxspec
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
+)
+
+func row() *store.Sandbox {
+	return &store.Sandbox{
+		ID:           "01TEST",
+		Status:       "stopped",
+		Image:        "sandboxd-base:0.3.0", // what it was CREATED from
+		WorkspaceMnt: "/var/lib/sandboxed/workspaces/01TEST",
+		Ports:        []int{3000},
+		WebPort:      sql.NullInt64{Int64: 3000, Valid: true},
+		Visibility:   "private",
+	}
+}
+
+func TestBuildReproducesTheHardenedCreateFlags(t *testing.T) {
+	s := Build(row(), Env{Image: "sandboxd-base:0.4.0", Network: "sandboxd_net", PreviewDomain: "example.test", PreviewEntrypoint: "web"})
+
+	if s.Name != "s-01TEST" || s.Hostname != "s-01TEST" {
+		t.Errorf("name/hostname = %q/%q", s.Name, s.Hostname)
+	}
+	// The point of recreation: the CURRENT image, not the row's old one.
+	if s.Image != "sandboxd-base:0.4.0" {
+		t.Errorf("image = %q, want the instance's current image", s.Image)
+	}
+	if !s.ReadOnly {
+		t.Error("rootfs must stay read-only")
+	}
+	if len(s.CapDrop) != 1 || s.CapDrop[0] != "ALL" {
+		t.Errorf("CapDrop = %v, want [ALL]", s.CapDrop)
+	}
+	if len(s.SecurityOpt) != 1 || s.SecurityOpt[0] != "no-new-privileges" {
+		t.Errorf("SecurityOpt = %v", s.SecurityOpt)
+	}
+	if s.PidsLimit != 1024 {
+		t.Errorf("PidsLimit = %d", s.PidsLimit)
+	}
+	// The workspace bind mount is what makes recreation safe.
+	if len(s.Volumes) == 0 || !strings.HasSuffix(s.Volumes[0], ":/home/sandbox") {
+		t.Errorf("volumes = %v, want the workspace mounted at /home/sandbox", s.Volumes)
+	}
+}
+
+func TestBuildEmitsPreviewLabelsForStoredPorts(t *testing.T) {
+	s := Build(row(), Env{Image: "img", PreviewDomain: "example.test", PreviewEntrypoint: "web"})
+	joined := strings.Join(s.Labels, "\n")
+	for _, want := range []string{"traefik.enable=true", "s-01TEST-3000", "example.test"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("labels missing %q\ngot: %s", want, joined)
+		}
+	}
+}
+
+func TestBuildAddsTheWebPortWhenMissingFromPorts(t *testing.T) {
+	r := row()
+	r.Ports = []int{8080}
+	r.WebPort = sql.NullInt64{Int64: 3000, Valid: true}
+	s := Build(r, Env{Image: "img", PreviewDomain: "d", PreviewEntrypoint: "web"})
+	joined := strings.Join(s.Labels, "\n")
+	if !strings.Contains(joined, "s-01TEST-3000") || !strings.Contains(joined, "s-01TEST-8080") {
+		t.Errorf("both the requested and the web port need routers, got:\n%s", joined)
+	}
+}
+
+func TestBuildPortlessSandboxGetsNoPreviewRouters(t *testing.T) {
+	r := row()
+	r.Ports = nil
+	s := Build(r, Env{Image: "img", PreviewDomain: "d", PreviewEntrypoint: "web"})
+	if strings.Contains(strings.Join(s.Labels, "\n"), "routers") {
+		t.Errorf("a port-less sandbox must stay preview-less, got %v", s.Labels)
+	}
+}
+
+func TestBuildPassesRuntimeAndDNSForGvisor(t *testing.T) {
+	s := Build(row(), Env{Image: "img", Runtime: "runsc", DNSResolvConf: "/var/lib/sandboxed/gvisor-resolv.conf"})
+	if s.Runtime != "runsc" {
+		t.Errorf("Runtime = %q", s.Runtime)
+	}
+	if !strings.Contains(strings.Join(s.Volumes, "\n"), "/etc/resolv.conf:ro") {
+		t.Errorf("gVisor needs the resolv.conf mount, got %v", s.Volumes)
+	}
+}
+
+func TestBuildForwardsRuntimedEnv(t *testing.T) {
+	s := Build(row(), Env{
+		Image: "img", RuntimePreset: "node-express",
+		AgentProxyURL: "http://sandboxd:9100", OpencodeZenPath: "zen",
+	})
+	joined := strings.Join(s.Env, "\n")
+	for _, want := range []string{
+		"RUNTIMED_RUNTIME_PRESET=node-express",
+		"RUNTIMED_ANTHROPIC_PROXY=http://sandboxd:9100",
+		"SANDBOXD_OPENCODE_ZEN_PATH=zen",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("env missing %q\ngot: %s", want, joined)
+		}
+	}
+}
+
+func TestNeedsRecreate(t *testing.T) {
+	cases := []struct {
+		name, container, current string
+		want                     bool
+	}{
+		{"stale image after upgrade", "sandboxd-base:0.3.0", "sandboxd-base:0.4.0", true},
+		{"already current", "sandboxd-base:0.4.0", "sandboxd-base:0.4.0", false},
+		{"unknown container image", "", "sandboxd-base:0.4.0", false},
+		{"unknown current image", "sandboxd-base:0.3.0", "", false},
+	}
+	for _, tc := range cases {
+		if got := NeedsRecreate(tc.container, tc.current); got != tc.want {
+			t.Errorf("%s: NeedsRecreate(%q,%q) = %v, want %v", tc.name, tc.container, tc.current, got, tc.want)
+		}
+	}
+}

--- a/control-plane/internal/wake/handler.go
+++ b/control-plane/internal/wake/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/egress"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/idlock"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/metrics"
+	"github.com/tastyeffectco/sandboxd/control-plane/internal/sandboxspec"
 	"github.com/tastyeffectco/sandboxd/control-plane/internal/store"
 )
 
@@ -64,11 +65,27 @@ type Handler struct {
 	// --memory ceiling on the container still applies.
 	SetMemoryHigh bool
 
+	// Recreate rebuilds a sandbox container from its stored row when the
+	// container is missing, or was created from an older base image than the
+	// instance now runs (an upgrade rebuilt the image, and with it runtimed —
+	// the in-sandbox supervisor). Without this, long-lived sandboxes keep an
+	// old runtimed forever and miss new agent/model support. nil-safe: when
+	// unset the wake path behaves exactly as before.
+	Recreate RecreateFunc
+
+	// Image is the base image the instance currently runs; a container built
+	// from a different one is stale (see Recreate).
+	Image string
+
 	hostRE *regexp.Regexp
 
 	mu       sync.Mutex
 	inflight map[string]*inflightWake
 }
+
+// RecreateFunc rebuilds the container for a sandbox row (workspace preserved)
+// and returns nil when the container is ready to start.
+type RecreateFunc func(ctx context.Context, sb *store.Sandbox) error
 
 // Config holds the env-tunable knobs the handler needs.
 type Config struct {
@@ -276,6 +293,39 @@ func (h *Handler) serve(r *http.Request, w http.ResponseWriter, id, port string,
 		h.respondAdmissionDenied(w, id, outcome, isHTML)
 		metrics.Wakes.WithLabelValues("admission_denied").Inc()
 		return
+	}
+
+	// 2b. Self-heal the container before starting it. Two cases, both fixed by
+	// rebuilding from the stored row (all durable state is in the workspace
+	// bind mount, so this is lossless):
+	//   - the container is gone (pruned, or removed by hand)
+	//   - it was created from an older base image than we run now, i.e. an
+	//     upgrade rebuilt the image and its runtimed. Starting it as-is would
+	//     silently keep the OLD in-sandbox supervisor and miss new agent/model
+	//     support ("Model X is not supported" on an up-to-date install).
+	if h.Recreate != nil {
+		stale := false
+		cur, ierr := h.Docker.Inspect(ctx, "s-"+id)
+		switch {
+		case ierr == docker.ErrNotFound:
+			stale = true
+			log.Info("wake: container missing — recreating from the stored row")
+		case ierr != nil:
+			log.Warn("wake: pre-start inspect failed (continuing)", "err", ierr.Error())
+		case sandboxspec.NeedsRecreate(cur.Config.Image, h.Image):
+			stale = true
+			log.Info("wake: container built from an older image — recreating",
+				"container_image", cur.Config.Image, "current_image", h.Image)
+		}
+		if stale {
+			if err := h.Recreate(ctx, sb); err != nil {
+				wf.err = err
+				log.Warn("wake: recreate failed", "err", err.Error())
+				h.respondError(w, id, "recreate_failed", isHTML)
+				metrics.Wakes.WithLabelValues("recreate_failed").Inc()
+				return
+			}
+		}
 	}
 
 	// 3. docker start (idempotent).


### PR DESCRIPTION
**The gap you hit:** `./upgrade.sh` rebuilds the base image (#90 made sure of that), but the image carries **runtimed** — and existing containers keep the OLD runtimed until they are recreated. So an up-to-date instance still ran old supervisors in long-lived sandboxes, and MiniMax tasks failed with *'Model MiniMax-M3 is not supported'*. Removing the container by hand was worse: nothing rebuilt it, `start` returned `sandbox_capacity`, project unreachable.

**Fix — starting a sandbox now self-heals it.** Before `docker start`, the wake path inspects the container and rebuilds it from the stored row when it is **missing**, or was created from a **different base image** than the instance now runs. Upgrades therefore reach every sandbox the next time it wakes, with no operator action.

**Lossless by construction:** all durable state is in the workspace bind mount and the rootfs is read-only — recreating touches nothing the user owns.

New `internal/sandboxspec` builds the RunSpec from a `store.Sandbox` (read-only, cap-drop ALL, no-new-privileges, pids/tmpfs limits, workspace mount, Traefik labels, runtimed env, gVisor runtime + resolv.conf) so a recreated container matches a created one apart from the newer image. **8 unit tests**: flag set, preview labels incl. web-port insertion + port-less case, gVisor, env forwarding, staleness predicate.

**Verified on the live instance** (control plane built from this branch): a sandbox whose container had been deleted was restored by one `start` call — log `wake: container missing — recreating from the stored row` — came up on `sandboxd-base:0.4.0` with a **MiniMax-aware runtimed**, workspace byte-identical (4,013,944 KB before and after), app serving **200**, and the MiniMax task that previously failed *'not supported'* now runs.

Not merged — per the new rule, awaiting your test verdict.