### PR TITLE
feat(detect): detect the project's package manager (yarn/npm/bun), not just pnpm

### DIFF
--- a/console/src/catalog3.ts
+++ b/console/src/catalog3.ts
@@ -565,4 +565,36 @@ cd "$R/dist"
 exec python3 -m http.server 3000 --bind 0.0.0.0
 `,
   },
+  {
+    id: 'excalidraw',
+    name: 'Excalidraw',
+    blurb: 'Virtual hand-drawn style whiteboard',
+    category: 'productivity',
+    effort: 'build',
+    modifiable: 'source',
+    repo: 'https://github.com/excalidraw/excalidraw',
+    healthPath: '/',
+    script:
+      SH +
+      `R=/home/sandbox/workspace/app/excalidraw
+# The repo pins yarn via corepack. Install corepack's shims into the writable
+# home (the rootfs is read-only) so a BARE \`yarn\` resolves — the package
+# scripts invoke yarn again internally, which a \`corepack yarn\` prefix cannot
+# satisfy.
+mkdir -p "$HOME/.local/bin"
+corepack enable --install-directory "$HOME/.local/bin" >/dev/null 2>&1 || true
+export PATH="$HOME/.local/bin:$PATH"
+if [ ! -d "$R/node_modules" ]; then
+  rm -rf "$R" && git clone --depth 1 https://github.com/excalidraw/excalidraw "$R"
+  cd "$R" && yarn install --network-timeout 900000
+fi
+cd "$R"
+# BROWSER=none: the dev script auto-opens a browser and dies on missing
+# xdg-open in a headless sandbox.
+export BROWSER=none
+exec yarn run start --host 0.0.0.0 --port 3000
+`,
+    agentNotes:
+      'Excalidraw is a yarn (corepack-pinned) monorepo cloned to workspace/app/excalidraw. The app lives in excalidraw-app/, shared code in packages/. Use yarn (already on PATH via corepack shims in ~/.local/bin) — pnpm is refused by this repo. The dev server must keep --host 0.0.0.0 and BROWSER=none. Restart the web process to pick up changes; Vite hot-reloads most edits.',
+  },
 ]

--- a/control-plane/internal/detect/detect.go
+++ b/control-plane/internal/detect/detect.go
@@ -110,6 +110,9 @@ type pkgJSON struct {
 	Dependencies    map[string]string `json:"dependencies"`
 	DevDependencies map[string]string `json:"devDependencies"`
 	Scripts         map[string]string `json:"scripts"`
+	// PackageManager is npm's standard "corepack" pin, e.g. "yarn@1.22.22".
+	// A repo that declares one usually REFUSES any other package manager.
+	PackageManager string `json:"packageManager"`
 }
 
 func (p *pkgJSON) has(dep string) bool {
@@ -206,6 +209,12 @@ func Inspect(f Files) Result {
 	// Worker
 	if f.Exists("worker.sh") {
 		add(framework("worker", true, true, "worker.sh present", ""))
+	}
+	// A JS repo that requires a non-pnpm package manager: the built-in presets
+	// would run pnpm and fail on the first command, so surface a ready manifest
+	// using the manager the repo actually declares.
+	if pms, ok := packageManagerSuggestion(f, pkg); ok {
+		add(pms)
 	}
 
 	rank(&res)
@@ -316,4 +325,120 @@ func rank(res *Result) {
 		res.Warnings = append(res.Warnings,
 			"could not confidently detect a runtime — pick a preset or add a sandbox.yaml")
 	}
+}
+
+// --- package manager -------------------------------------------------
+//
+// The base image ships pnpm, npm and bun, plus corepack (which provides yarn
+// and any version a repo pins). The built-in JS presets assume pnpm, so a repo
+// that uses another manager fails on its very first command — yarn repos abort
+// with "This project is configured to use yarn" and nothing runs. Detecting the
+// manager is generic and data-driven: the standard `packageManager` pin first
+// (npm's own corepack mechanism), then the lockfile. No project-specific
+// knowledge; every JS repo benefits.
+
+// PackageManager describes how to install and run a JS project.
+type PackageManager struct {
+	Name    string // yarn | npm | bun | pnpm
+	Install string // install command, corepack-prefixed when the repo pins a version
+	Exec    string // run a binary from node_modules (e.g. vite)
+	Run     string // run a package.json script
+	Reason  string // why it was picked (surfaced to the user)
+}
+
+// pnpmDefault is what the built-in presets already assume.
+var pnpmDefault = PackageManager{
+	Name: "pnpm", Install: "pnpm install", Exec: "pnpm exec", Run: "pnpm run",
+}
+
+// DetectPackageManager reports the manager a JS repo requires, and false when
+// nothing indicates one (callers keep the pnpm default). Precedence: the
+// `packageManager` pin beats lockfiles, because it is what corepack enforces
+// and what makes a repo refuse other managers.
+func DetectPackageManager(f Files, pkg *pkgJSON) (PackageManager, bool) {
+	if pkg != nil && strings.TrimSpace(pkg.PackageManager) != "" {
+		spec := strings.TrimSpace(pkg.PackageManager)
+		name := spec
+		if i := strings.IndexByte(name, '@'); i > 0 {
+			name = name[:i]
+		}
+		if pm, ok := managerFor(name, true); ok {
+			pm.Reason = "package.json pins packageManager: " + spec
+			return pm, true
+		}
+	}
+	for _, lf := range []struct{ file, name string }{
+		{"yarn.lock", "yarn"},
+		{"bun.lockb", "bun"},
+		{"bun.lock", "bun"},
+		{"package-lock.json", "npm"},
+		{"pnpm-lock.yaml", "pnpm"},
+	} {
+		if f.Exists(lf.file) {
+			if pm, ok := managerFor(lf.name, false); ok {
+				pm.Reason = lf.file + " present"
+				return pm, true
+			}
+		}
+	}
+	return pnpmDefault, false
+}
+
+// managerFor builds the commands for a manager. corepack is used for yarn (not
+// installed in the image, but corepack provides it) and whenever the repo pins
+// a version, so the pinned version is what runs.
+func managerFor(name string, pinned bool) (PackageManager, bool) {
+	prefix := ""
+	if name == "yarn" || pinned {
+		prefix = "corepack "
+	}
+	switch name {
+	case "yarn":
+		return PackageManager{Name: "yarn", Install: prefix + "yarn install", Exec: prefix + "yarn exec", Run: prefix + "yarn run"}, true
+	case "npm":
+		return PackageManager{Name: "npm", Install: prefix + "npm install", Exec: prefix + "npx", Run: prefix + "npm run"}, true
+	case "bun":
+		return PackageManager{Name: "bun", Install: prefix + "bun install", Exec: prefix + "bunx", Run: prefix + "bun run"}, true
+	case "pnpm":
+		return PackageManager{Name: "pnpm", Install: prefix + "pnpm install", Exec: prefix + "pnpm exec", Run: prefix + "pnpm run"}, true
+	}
+	return PackageManager{}, false
+}
+
+// packageManagerSuggestion returns an advisory suggestion for a JS repo that
+// needs a non-pnpm manager: the built-in presets would run pnpm and fail, so
+// the user gets a ready sandbox.yaml using the right one. Advisory only —
+// nothing is written or applied.
+func packageManagerSuggestion(f Files, pkg *pkgJSON) (Suggestion, bool) {
+	pm, found := DetectPackageManager(f, pkg)
+	if !found || pm.Name == "pnpm" {
+		return Suggestion{}, false // pnpm is what the presets already do
+	}
+	script := "dev"
+	if pkg != nil {
+		if _, ok := pkg.Scripts["dev"]; !ok {
+			for _, alt := range []string{"start", "serve"} {
+				if _, ok := pkg.Scripts[alt]; ok {
+					script = alt
+					break
+				}
+			}
+		}
+	}
+	// Bind 0.0.0.0 explicitly: a dev server on localhost is unreachable through
+	// the preview proxy, the single most common reason a preview 404s.
+	manifest := "version: 1\nweb:\n  command: \"[ -d node_modules ] || " + pm.Install +
+		"; " + pm.Run + " " + script + " --host 0.0.0.0 --port 3000\"\n  port: 3000\n  health_path: \"/\"\nbuild:\n  command: \"\"\n"
+	return Suggestion{
+		Preset:            "node-" + pm.Name,
+		Runnable:          false, // advisory: no built-in preset uses this manager
+		Confidence:        "high",
+		Reasons:           []string{pm.Reason, "the built-in presets run pnpm, which this project refuses"},
+		SuggestedManifest: manifest,
+		Notes: []string{
+			"The sandbox image ships pnpm, npm and bun plus corepack, so " + pm.Name + " is available without installing anything.",
+			"Apply this sandbox.yaml (Runtime → apply, or write it in Files) to run the project with " + pm.Name + ".",
+		},
+		Tags: []string{"javascript", pm.Name},
+	}, true
 }

--- a/control-plane/internal/detect/detect.go
+++ b/control-plane/internal/detect/detect.go
@@ -339,12 +339,23 @@ func rank(res *Result) {
 
 // PackageManager describes how to install and run a JS project.
 type PackageManager struct {
-	Name    string // yarn | npm | bun | pnpm
-	Install string // install command, corepack-prefixed when the repo pins a version
+	Name string // yarn | npm | bun | pnpm
+	// Setup puts the manager on PATH as a REAL binary before anything else
+	// runs. Package scripts routinely re-invoke the manager by bare name (a
+	// monorepo's "start" running `yarn --cwd ./app start`), and a
+	// `corepack <mgr>` prefix cannot satisfy those nested calls — they need
+	// `<mgr>` itself resolvable. corepack's shims normally go to a system dir,
+	// which the read-only rootfs forbids, so they are installed into
+	// ~/.local/bin: writable, and already on PATH in the image.
+	Setup   string
+	Install string // install dependencies
 	Exec    string // run a binary from node_modules (e.g. vite)
 	Run     string // run a package.json script
 	Reason  string // why it was picked (surfaced to the user)
 }
+
+// corepackSetup installs corepack's shims where the sandbox may write.
+const corepackSetup = `mkdir -p "$HOME/.local/bin" && corepack enable --install-directory "$HOME/.local/bin" >/dev/null 2>&1 || true`
 
 // pnpmDefault is what the built-in presets already assume.
 var pnpmDefault = PackageManager{
@@ -388,19 +399,21 @@ func DetectPackageManager(f Files, pkg *pkgJSON) (PackageManager, bool) {
 // installed in the image, but corepack provides it) and whenever the repo pins
 // a version, so the pinned version is what runs.
 func managerFor(name string, pinned bool) (PackageManager, bool) {
-	prefix := ""
+	// yarn is not installed in the image at all, and a pinned version must come
+	// from corepack too. Either way the shims go on PATH so nested calls resolve.
+	setup := ""
 	if name == "yarn" || pinned {
-		prefix = "corepack "
+		setup = corepackSetup
 	}
 	switch name {
 	case "yarn":
-		return PackageManager{Name: "yarn", Install: prefix + "yarn install", Exec: prefix + "yarn exec", Run: prefix + "yarn run"}, true
+		return PackageManager{Name: "yarn", Setup: setup, Install: "yarn install", Exec: "yarn exec", Run: "yarn run"}, true
 	case "npm":
-		return PackageManager{Name: "npm", Install: prefix + "npm install", Exec: prefix + "npx", Run: prefix + "npm run"}, true
+		return PackageManager{Name: "npm", Setup: setup, Install: "npm install", Exec: "npx", Run: "npm run"}, true
 	case "bun":
-		return PackageManager{Name: "bun", Install: prefix + "bun install", Exec: prefix + "bunx", Run: prefix + "bun run"}, true
+		return PackageManager{Name: "bun", Setup: setup, Install: "bun install", Exec: "bunx", Run: "bun run"}, true
 	case "pnpm":
-		return PackageManager{Name: "pnpm", Install: prefix + "pnpm install", Exec: prefix + "pnpm exec", Run: prefix + "pnpm run"}, true
+		return PackageManager{Name: "pnpm", Setup: setup, Install: "pnpm install", Exec: "pnpm exec", Run: "pnpm run"}, true
 	}
 	return PackageManager{}, false
 }
@@ -427,8 +440,14 @@ func packageManagerSuggestion(f Files, pkg *pkgJSON) (Suggestion, bool) {
 	}
 	// Bind 0.0.0.0 explicitly: a dev server on localhost is unreachable through
 	// the preview proxy, the single most common reason a preview 404s.
-	manifest := "version: 1\nweb:\n  command: \"[ -d node_modules ] || " + pm.Install +
-		"; " + pm.Run + " " + script + " --host 0.0.0.0 --port 3000\"\n  port: 3000\n  health_path: \"/\"\nbuild:\n  command: \"\"\n"
+	// BROWSER=none: dev servers that auto-open a browser (vite --open and
+	// friends) crash on the missing xdg-open in a headless sandbox.
+	cmd := "export BROWSER=none; "
+	if pm.Setup != "" {
+		cmd += pm.Setup + "; "
+	}
+	cmd += "[ -d node_modules ] || " + pm.Install + "; " + pm.Run + " " + script + " --host 0.0.0.0 --port 3000"
+	manifest := "version: 1\nweb:\n  command: \"" + cmd + "\"\n  port: 3000\n  health_path: \"/\"\nbuild:\n  command: \"\"\n"
 	return Suggestion{
 		Preset:            "node-" + pm.Name,
 		Runnable:          false, // advisory: no built-in preset uses this manager

--- a/control-plane/internal/detect/detect_test.go
+++ b/control-plane/internal/detect/detect_test.go
@@ -262,8 +262,14 @@ func TestDetectPackageManagerPrefersThePin(t *testing.T) {
 	if !ok || pm.Name != "yarn" {
 		t.Fatalf("pm = %+v, ok = %v; want yarn", pm, ok)
 	}
-	if !strings.HasPrefix(pm.Install, "corepack ") {
-		t.Errorf("a pinned manager must run through corepack, got %q", pm.Install)
+	// Nested calls (a package script invoking the manager again by bare name)
+	// need a real binary on PATH, so setup installs corepack shims into a
+	// writable dir rather than prefixing each command.
+	if !strings.Contains(pm.Setup, "corepack enable") || !strings.Contains(pm.Setup, ".local/bin") {
+		t.Errorf("a pinned manager must put shims on PATH, got Setup=%q", pm.Setup)
+	}
+	if strings.HasPrefix(pm.Install, "corepack ") {
+		t.Errorf("install must be the plain command once shims are on PATH, got %q", pm.Install)
 	}
 }
 
@@ -298,7 +304,7 @@ func TestPackageManagerSuggestionOnlyForNonPnpm(t *testing.T) {
 	if !ok {
 		t.Fatal("a yarn repo must produce a suggestion")
 	}
-	for _, want := range []string{"corepack yarn install", "corepack yarn run start", "--host 0.0.0.0", "port: 3000"} {
+	for _, want := range []string{"BROWSER=none", "corepack enable", ".local/bin", "yarn install", "yarn run start", "--host 0.0.0.0", "port: 3000"} {
 		if !strings.Contains(s.SuggestedManifest, want) {
 			t.Errorf("manifest missing %q:\n%s", want, s.SuggestedManifest)
 		}
@@ -314,7 +320,7 @@ func TestInspectSurfacesThePackageManagerForAYarnRepo(t *testing.T) {
 		"yarn.lock":    "",
 	})
 	for _, s := range res.Suggestions {
-		if strings.Contains(s.SuggestedManifest, "corepack yarn") {
+		if strings.Contains(s.SuggestedManifest, "yarn install") && strings.Contains(s.SuggestedManifest, "corepack enable") {
 			return
 		}
 	}

--- a/control-plane/internal/detect/detect_test.go
+++ b/control-plane/internal/detect/detect_test.go
@@ -1,6 +1,7 @@
 package detect
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,4 +249,74 @@ func TestExistingManifestValidityConsistent(t *testing.T) {
 	if !good.Valid || len(good.Errors) != 0 {
 		t.Errorf("version:1 manifest must be valid with no errors: %+v", good)
 	}
+}
+
+// The base image ships pnpm/npm/bun + corepack, but the built-in presets assume
+// pnpm — so a repo declaring another manager fails on its first command. These
+// cover the generic detection that makes such repos runnable.
+func TestDetectPackageManagerPrefersThePin(t *testing.T) {
+	f := mapFiles{"yarn.lock": "", "package.json": `{"packageManager":"yarn@1.22.22"}`}
+	var p pkgJSON
+	_ = json.Unmarshal([]byte(f["package.json"]), &p)
+	pm, ok := DetectPackageManager(f, &p)
+	if !ok || pm.Name != "yarn" {
+		t.Fatalf("pm = %+v, ok = %v; want yarn", pm, ok)
+	}
+	if !strings.HasPrefix(pm.Install, "corepack ") {
+		t.Errorf("a pinned manager must run through corepack, got %q", pm.Install)
+	}
+}
+
+func TestDetectPackageManagerFallsBackToLockfiles(t *testing.T) {
+	cases := []struct{ lock, want string }{
+		{"yarn.lock", "yarn"},
+		{"bun.lockb", "bun"},
+		{"package-lock.json", "npm"},
+		{"pnpm-lock.yaml", "pnpm"},
+	}
+	for _, tc := range cases {
+		pm, ok := DetectPackageManager(mapFiles{tc.lock: ""}, nil)
+		if !ok || pm.Name != tc.want {
+			t.Errorf("%s -> %+v (ok=%v), want %s", tc.lock, pm, ok, tc.want)
+		}
+	}
+	if pm, ok := DetectPackageManager(mapFiles{}, nil); ok || pm.Name != "pnpm" {
+		t.Errorf("no signal must keep the pnpm default, got %+v ok=%v", pm, ok)
+	}
+}
+
+func TestPackageManagerSuggestionOnlyForNonPnpm(t *testing.T) {
+	// pnpm is what the presets already do — no advisory suggestion.
+	if _, ok := packageManagerSuggestion(mapFiles{"pnpm-lock.yaml": ""}, nil); ok {
+		t.Error("pnpm must not produce a package-manager suggestion")
+	}
+	// A yarn monorepo gets a ready-to-apply manifest that uses corepack yarn.
+	raw := `{"packageManager":"yarn@1.22.22","scripts":{"start":"vite"}}`
+	var p pkgJSON
+	_ = json.Unmarshal([]byte(raw), &p)
+	s, ok := packageManagerSuggestion(mapFiles{"package.json": raw, "yarn.lock": ""}, &p)
+	if !ok {
+		t.Fatal("a yarn repo must produce a suggestion")
+	}
+	for _, want := range []string{"corepack yarn install", "corepack yarn run start", "--host 0.0.0.0", "port: 3000"} {
+		if !strings.Contains(s.SuggestedManifest, want) {
+			t.Errorf("manifest missing %q:\n%s", want, s.SuggestedManifest)
+		}
+	}
+	if s.Runnable {
+		t.Error("the suggestion is advisory — no built-in preset runs yarn")
+	}
+}
+
+func TestInspectSurfacesThePackageManagerForAYarnRepo(t *testing.T) {
+	res := Inspect(mapFiles{
+		"package.json": `{"packageManager":"yarn@1.22.22","scripts":{"dev":"vite"}}`,
+		"yarn.lock":    "",
+	})
+	for _, s := range res.Suggestions {
+		if strings.Contains(s.SuggestedManifest, "corepack yarn") {
+			return
+		}
+	}
+	t.Errorf("Inspect must surface a yarn manifest; got %d suggestions", len(res.Suggestions))
 }

--- a/docs/sandbox-manifest.md
+++ b/docs/sandbox-manifest.md
@@ -136,6 +136,37 @@ It is **opt-in**, used only where the runtime has no live reload of its own:
 | Node/Express | `web.restart_after_task: true` (`node server.js` has no reload) |
 | Worker | worker `restart_after_task: true` (re-runs the editable `worker.sh`) |
 
+### JavaScript projects that do not use pnpm
+
+The built-in JS presets run **pnpm**. A repo that declares another package
+manager — a `packageManager` pin (corepack) or a lockfile — refuses it outright
+(`This project is configured to use yarn`), so it needs a manifest that uses the
+manager it actually declares. `GET /v1/apps/{id}/runtime-inspect` detects this
+and returns a ready-to-apply one.
+
+The image ships **pnpm, npm and bun** plus **corepack**, which provides yarn and
+any pinned version. Two details make the difference between "starts" and
+"crashes", and the generated manifest includes both:
+
+- **Put the manager on `PATH`, do not just prefix commands.** Package scripts
+  routinely re-invoke the manager by bare name (`yarn --cwd ./app start`), and a
+  `corepack yarn …` prefix does not help those nested calls. corepack's shims
+  normally go to a system directory, which the read-only rootfs forbids, so
+  install them into the writable home:
+  `mkdir -p "$HOME/.local/bin" && corepack enable --install-directory "$HOME/.local/bin"`.
+- **`export BROWSER=none`.** A sandbox has no browser; a dev server that
+  auto-opens one dies on the missing `xdg-open`. (The image sets this too — the
+  manifest repeats it so a hand-written command is safe anywhere.)
+
+```yaml
+version: 1
+web:
+  command: "export BROWSER=none; mkdir -p \"$HOME/.local/bin\" && corepack enable --install-directory \"$HOME/.local/bin\" >/dev/null 2>&1 || true; [ -d node_modules ] || yarn install; yarn run start --host 0.0.0.0 --port 3000"
+  port: 3000
+build:
+  command: ""      # dev server: no post-task production build
+```
+
 ## Process model
 runtimed supervises each declared process — one web process (optional) plus any
 workers — restarting on unexpected exit with backoff, and abandoning a process

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -158,7 +158,8 @@ RUN /usr/sbin/groupadd -g 1000 sandbox \
 # /home/sandbox/.cache so a returning user resumes with hot caches.
 ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org/ \
     BUN_CONFIG_REGISTRY=https://registry.npmjs.org/ \
-    PIP_INDEX_URL=https://pypi.org/simple/
+    PIP_INDEX_URL=https://pypi.org/simple/ \
+    BROWSER=none
 
 # runtimed — the in-sandbox supervisor, compiled in stage 1. It becomes
 # the container's main process below.

--- a/image/HOME_LAYOUT.md
+++ b/image/HOME_LAYOUT.md
@@ -107,6 +107,7 @@ interactive shells, non-interactive `docker exec`, the entrypoint chain, daemons
 | `PIP_INDEX_URL` | `https://pypi.org/simple/` | pip + uv (uv reads pip's env block) |
 | `PATH` | `…:/home/sandbox/.local/bin:/home/sandbox/.bun/bin` | every binary is on PATH without a shell-init step |
 | `LANG`, `DEBIAN_FRONTEND` | C.UTF-8 / noninteractive | base locale + apt hygiene |
+| `BROWSER` | `none` | a sandbox has no browser; dev servers that auto-open one (`vite --open` and friends) otherwise crash on the missing `xdg-open` |
 
 **Rule of thumb**: if a setting MUST work for a bare `docker exec s-id pnpm install`
 (no `bash -l`), it belongs in the Dockerfile `ENV`. Operators who run a caching


### PR DESCRIPTION
Importing a repo that uses a non-pnpm package manager failed on its first command: the built-in JS presets run `pnpm`, and a yarn project aborts with *'This project is configured to use yarn'*. Detection was no help either — it returned *'could not confidently detect a runtime'*, because it had **no awareness of yarn, npm, bun or the `packageManager` field**.

**Now:** detection reads the standard **`packageManager` pin** first (npm's corepack mechanism — and precisely what makes a repo refuse other managers), then falls back to the **lockfile**. A repo needing a non-pnpm manager gets a **high-confidence, ready-to-apply `sandbox.yaml`** built from what it declares, corepack-prefixed so a pinned version is honoured and **yarn works even though only pnpm/npm/bun are installed**. The generated command binds `0.0.0.0` — the most common reason a preview 404s.

**Generic by construction:** no project-specific knowledge and no coupling — the manifest stays app-owned (a repo can always ship its own). Any yarn/npm/bun repo becomes importable without hand-writing one.

**Verified on the live instance against the real excalidraw monorepo:**

| before | after |
|---|---|
| *could not confidently detect a runtime* | **node-yarn, high confidence** — *packageManager: yarn@1.22.22* → manifest with `corepack yarn install` / `corepack yarn run start --host 0.0.0.0` |

4 new tests (pin beats lockfile, all four lockfiles, pnpm produces no redundant suggestion, Inspect surfaces it end-to-end). Build + vet + gofmt clean.