### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ copy-pasteable runbook.
 Stars are how other builders find sandboxd — it's the fastest way to support the
 project (and it keeps us going). Thank you 🙏
 
+[![Star History Chart](https://star-history.dera.page/svg?repos=tastyeffectco/sandboxd&type=Date)](https://star-history.dera.page/#tastyeffectco/sandboxd&type=Date)
 
 ## License
 


### PR DESCRIPTION
The Star History chart in the README was removed because the current chart is broken. Restore it using the working chart URL so visitors can again see the repository's star history.

Related commit: 15e1b21 (Remove Star History Chart from README).